### PR TITLE
Update proxy.py to set a timeout for incoming socket connections.

### DIFF
--- a/google/cloud/dataproc_spark_connect/client/proxy.py
+++ b/google/cloud/dataproc_spark_connect/client/proxy.py
@@ -192,6 +192,7 @@ class DataprocSessionProxy(object):
             s.release()
             while not self._killed:
                 conn, addr = frontend_socket.accept()
+                conn.settimeout(1)
                 logger.debug(f"Accepted a connection from {addr}...")
                 self._conn_number += 1
                 threading.Thread(

--- a/google/cloud/dataproc_spark_connect/client/proxy.py
+++ b/google/cloud/dataproc_spark_connect/client/proxy.py
@@ -210,6 +210,13 @@ class DataprocSessionProxy(object):
             s.release()
             while not self._killed:
                 conn, addr = frontend_socket.accept()
+                # Set a timeout on how long we will allow send/recv calls to block
+                #
+                # The code that reads and writes to this connection will retry
+                # on timeouts, so this is a safe change.
+                #
+                # The chosen timeout is a very short one because it allows us
+                # to more quickly detect when a connection has been closed.
                 conn.settimeout(1)
                 logger.debug(f"Accepted a connection from {addr}...")
                 self._conn_number += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 google-api-core>=2.19.1
-# TODO: Add google_cloud_dataproc version once it's available
+google-cloud-dataproc>=5.15.1
 pandas>=2.2.2
 pyarrow>=17.0.0
 pyspark==3.5

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
     license="Apache 2.0",
     packages=find_namespace_packages(include=["google.*"]),
     install_requires=[
+        "google-api-core>=2.19.1",
+        "google-cloud-dataproc>=5.15.1",
         "wheel",
         "websockets",
         "pyspark>=3.5",

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -1,0 +1,135 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import socket
+import threading
+import time
+
+import pytest
+
+from google.cloud.dataproc_spark_connect.client.proxy import connect_sockets
+
+
+@pytest.fixture
+def test_message():
+    return """
+    ABCD
+    EFG
+    HIJK
+    LMNOP
+    QRS
+    TUV
+    WX
+    Y
+    Z
+    """
+
+
+@pytest.fixture(params=[None, 0.1])
+def outgoing_socket_timeout(request):
+    return request.param
+
+
+@pytest.fixture(params=[0, 0.1, 0.2])
+def backend_wait(request):
+    return request.param
+
+
+@pytest.fixture(params=[None, 0.1])
+def incoming_socket_timeout(request):
+    return request.param
+
+
+@pytest.fixture(params=[0, 0.1, 0.2])
+def client_wait(request):
+    return request.param
+
+
+@pytest.fixture
+def echo_server_conn(outgoing_socket_timeout, backend_wait):
+    def echo_messages(conn):
+        while True:
+            try:
+                time.sleep(backend_wait)
+                bs = conn.recv(1024)
+                if not bs:
+                    return
+                time.sleep(backend_wait)
+                while bs:
+                    try:
+                        conn.send(bs)
+                        bs = None
+                    except TimeoutError:
+                        pass
+            except TimeoutError:
+                pass
+
+    def echo_server(server_socket):
+        while True:
+            conn, _ = server_socket.accept()
+            conn.settimeout(outgoing_socket_timeout)
+            t = threading.Thread(target=echo_messages, args=[conn], daemon=True)
+            t.start()
+
+    with socket.create_server(("127.0.0.1", 0)) as server_socket:
+        t = threading.Thread(target=echo_server, args=[server_socket], daemon=True)
+        t.start()
+        yield socket.create_connection(server_socket.getsockname())
+
+
+def test_echo_server(echo_server_conn, test_message):
+    sent = []
+    received = []
+    for line in test_message.split():
+        sent.append(line)
+        echo_server_conn.send(line.encode())
+        received.append(echo_server_conn.recv(1024).decode())
+    assert '\n'.join(sent) == '\n'.join(received)
+
+
+@pytest.fixture
+def proxy_server_conn(incoming_socket_timeout, echo_server_conn):
+    def proxy_server(server_socket):
+        conn_number = 0
+        while True:
+            incoming_conn, _ = server_socket.accept()
+            t = threading.Thread(target=connect_sockets, args=[conn_number, incoming_conn, echo_server_conn], daemon=True)
+            t.start()
+            conn_number += 1
+
+    with socket.create_server(("127.0.0.1", 0)) as server_socket:
+        t = threading.Thread(target=proxy_server, args=[server_socket], daemon=True)
+        t.start()
+        conn = socket.create_connection(server_socket.getsockname())
+        conn.settimeout(incoming_socket_timeout)
+        yield conn
+
+
+def retry_on_timeouts(method, arg):
+    while True:
+        try:
+            return method(arg)
+        except TimeoutError:
+            pass
+
+
+def test_proxy_with_timeouts(client_wait, proxy_server_conn, test_message):
+    sent = []
+    received = []
+    for line in test_message.split():
+        time.sleep(client_wait)
+        sent.append(line)
+        retry_on_timeouts(proxy_server_conn.send, line.encode())
+        time.sleep(client_wait)
+        received.append(retry_on_timeouts(proxy_server_conn.recv, 1024).decode())
+    assert '\n'.join(sent) == '\n'.join(received)

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -82,7 +82,9 @@ def echo_server_conn(outgoing_socket_timeout, backend_wait):
             t.start()
 
     with socket.create_server(("127.0.0.1", 0)) as server_socket:
-        t = threading.Thread(target=echo_server, args=[server_socket], daemon=True)
+        t = threading.Thread(
+            target=echo_server, args=[server_socket], daemon=True
+        )
         t.start()
         yield socket.create_connection(server_socket.getsockname())
 
@@ -94,7 +96,7 @@ def test_echo_server(echo_server_conn, test_message):
         sent.append(line)
         echo_server_conn.send(line.encode())
         received.append(echo_server_conn.recv(1024).decode())
-    assert '\n'.join(sent) == '\n'.join(received)
+    assert "\n".join(sent) == "\n".join(received)
 
 
 @pytest.fixture
@@ -103,12 +105,18 @@ def proxy_server_conn(incoming_socket_timeout, echo_server_conn):
         conn_number = 0
         while True:
             incoming_conn, _ = server_socket.accept()
-            t = threading.Thread(target=connect_sockets, args=[conn_number, incoming_conn, echo_server_conn], daemon=True)
+            t = threading.Thread(
+                target=connect_sockets,
+                args=[conn_number, incoming_conn, echo_server_conn],
+                daemon=True,
+            )
             t.start()
             conn_number += 1
 
     with socket.create_server(("127.0.0.1", 0)) as server_socket:
-        t = threading.Thread(target=proxy_server, args=[server_socket], daemon=True)
+        t = threading.Thread(
+            target=proxy_server, args=[server_socket], daemon=True
+        )
         t.start()
         conn = socket.create_connection(server_socket.getsockname())
         conn.settimeout(incoming_socket_timeout)
@@ -131,5 +139,7 @@ def test_proxy_with_timeouts(client_wait, proxy_server_conn, test_message):
         sent.append(line)
         retry_on_timeouts(proxy_server_conn.send, line.encode())
         time.sleep(client_wait)
-        received.append(retry_on_timeouts(proxy_server_conn.recv, 1024).decode())
-    assert '\n'.join(sent) == '\n'.join(received)
+        received.append(
+            retry_on_timeouts(proxy_server_conn.recv, 1024).decode()
+        )
+    assert "\n".join(sent) == "\n".join(received)


### PR DESCRIPTION
This change sets a timeout for accepted incoming socket connections in the tunnel-over-websocket proxy.

Without this, sockets inherit the default timeout of `None`, which causes them to be blocking but never time out.