### PR TITLE
Point release-please at `main` branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,3 @@
 releaseType: python
 handleGHRelease: true
+primaryBranch: main


### PR DESCRIPTION
The release-please automation appears to be configured but it isn't apparently active yet. It looks like the app may default to releasing from the "master" branch, so I'm retargeting "main" here.