### PR TITLE
Rename /regions/ path to /locations/ in client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-build/
-dist/
-.idea
 *.egg-info/
 *~
+.idea
 __pycache__
+build/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info/
 *~
+.*.sw[nop]
 .idea
 __pycache__
 build/

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -196,13 +196,13 @@ class DataprocSparkSession(SparkSession):
                 session_id = self.generate_dataproc_session_id()
 
                 session_request.session_id = session_id
-                dataproc_config.name = f"projects/{self._project_id}/regions/{self._region}/sessions/{session_id}"
+                dataproc_config.name = f"projects/{self._project_id}/locations/{self._region}/sessions/{session_id}"
                 logger.debug(
                     f"Configurations used to create serverless session:\n {dataproc_config}"
                 )
                 session_request.session = dataproc_config
                 session_request.parent = (
-                    f"projects/{self._project_id}/regions/{self._region}"
+                    f"projects/{self._project_id}/locations/{self._region}"
                 )
 
                 logger.debug("Creating serverless session")

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -92,9 +92,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request = CreateSessionRequest.wrap(
             text_format.Parse(
                 """
-        parent: "projects/test-project/regions/test-region"
+        parent: "projects/test-project/locations/test-region"
         session {
-          name: "projects/test-project/regions/test-region/sessions/sc-20240702-103952-abcdef"
+          name: "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
           runtime_config {
             version: "_DEFAULT_RUNTIME_VERSION_"
           }
@@ -183,9 +183,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request = CreateSessionRequest.wrap(
             text_format.Parse(
                 """
-        parent: "projects/test-project/regions/test-region"
+        parent: "projects/test-project/locations/test-region"
         session {
-          name: "projects/test-project/regions/test-region/sessions/sc-20240702-103952-abcdef"
+          name: "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
           runtime_config {
             version: "_DEFAULT_RUNTIME_VERSION_"
             properties: {
@@ -306,9 +306,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request = CreateSessionRequest.wrap(
             text_format.Parse(
                 """
-        parent: "projects/test-project/regions/test-region"
+        parent: "projects/test-project/locations/test-region"
         session {
-          name: "projects/test-project/regions/test-region/sessions/sc-20240702-103952-abcdef"
+          name: "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
           runtime_config {
             version: "_DEFAULT_RUNTIME_VERSION_"
           }
@@ -407,9 +407,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request = CreateSessionRequest.wrap(
             text_format.Parse(
                 """
-        parent: "projects/test-project/regions/test-region"
+        parent: "projects/test-project/locations/test-region"
         session {
-          name: "projects/test-project/regions/test-region/sessions/sc-20240702-103952-abcdef"
+          name: "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
           runtime_config {
             version: "_DEFAULT_RUNTIME_VERSION_"
           }


### PR DESCRIPTION
The service now expects `/locations/` instead of `/regions/` in the path in calls agains the sessions API.

Note that there's a breakage in the upstream dependency of `google-cloud-dataproc`, so this needs to be patched to make tests pass locally. This still needs to be tested against the service.