### PR TITLE
Changes to gracefully handle 409 from session terminations.

### DIFF
--- a/google/cloud/spark_connect/session.py
+++ b/google/cloud/spark_connect/session.py
@@ -539,8 +539,8 @@ def terminate_s8s_session(
             sleep(1)
     except NotFound:
         logger.debug(f"Session {active_s8s_session_id} already deleted")
-    # Client will get 'Aborted' error if session creation is still in progress and 
-    # 'FailedPrecondition' if another termination is still in progress. 
+    # Client will get 'Aborted' error if session creation is still in progress and
+    # 'FailedPrecondition' if another termination is still in progress.
     # Both are retryable but we catch it and let TTL take care of cleanups.
     except (FailedPrecondition, Aborted):
         logger.debug(

--- a/google/cloud/spark_connect/session.py
+++ b/google/cloud/spark_connect/session.py
@@ -539,7 +539,9 @@ def terminate_s8s_session(
             sleep(1)
     except NotFound:
         logger.debug(f"Session {active_s8s_session_id} already deleted")
-    # Client will get Aborted if session creation is still in progress. 
+    # Client will get 'Aborted' error if session creation is still in progress and 
+    # 'FailedPrecondition' if another termination is still in progress. 
+    # Both are retryable but we catch it and let TTL take care of cleanups.
     except (FailedPrecondition, Aborted):
         logger.debug(
             f"Session {active_s8s_session_id} already terminated manually or terminated automatically through session ttl limits"

--- a/google/cloud/spark_connect/session.py
+++ b/google/cloud/spark_connect/session.py
@@ -539,6 +539,7 @@ def terminate_s8s_session(
             sleep(1)
     except NotFound:
         logger.debug(f"Session {active_s8s_session_id} already deleted")
+    # Client will get Aborted if session creation is still in progress. 
     except (FailedPrecondition, Aborted):
         logger.debug(
             f"Session {active_s8s_session_id} already terminated manually or terminated automatically through session ttl limits"

--- a/google/cloud/spark_connect/session.py
+++ b/google/cloud/spark_connect/session.py
@@ -25,7 +25,7 @@ from typing import Any, cast, ClassVar, Dict, Optional
 from google.api_core import retry
 from google.api_core.future.polling import POLLING_PREDICATE
 from google.api_core.client_options import ClientOptions
-from google.api_core.exceptions import FailedPrecondition, InvalidArgument, NotFound
+from google.api_core.exceptions import Aborted, FailedPrecondition, InvalidArgument, NotFound
 from google.cloud.dataproc_v1.types import sessions
 
 from google.cloud.spark_connect.client import DataprocChannelBuilder
@@ -539,7 +539,7 @@ def terminate_s8s_session(
             sleep(1)
     except NotFound:
         logger.debug(f"Session {active_s8s_session_id} already deleted")
-    except FailedPrecondition:
+    except (FailedPrecondition, Aborted):
         logger.debug(
             f"Session {active_s8s_session_id} already terminated manually or terminated automatically through session ttl limits"
         )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -605,7 +605,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             if session is not None:
                 session.stop()
             self.assertIsNone(GoogleSparkSession._active_s8s_session_uuid)
-    
+
     @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")


### PR DESCRIPTION
Session terminations can be aborted if a session is still being created. Handling that case gracefully. 