### PR TITLE
chore: Clean up dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,5 @@
 google-api-core>=2.19.1
 google-cloud-dataproc>=5.15.1
-pandas>=2.2.2
-pyarrow>=17.0.0
 pyspark==3.5
 setuptools>=72.0.0
 websockets>=12.0

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,7 @@ setup(
     install_requires=[
         "google-api-core>=2.19.1",
         "google-cloud-dataproc>=5.15.1",
-        "wheel",
         "websockets",
         "pyspark>=3.5",
-        "pandas",
-        "pyarrow",
     ],
 )


### PR DESCRIPTION
This removes indirect transitive dependencies from the package and renames `requirements.txt` to `requirements-dev.txt` to reflect the fact that this is not actually used by the package itself but is only used for development.