### PR TITLE
fix: Switch pyspark dependency to pyspark[connect]

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 google-api-core>=2.19.1
 google-cloud-dataproc>=5.15.1
-pyspark==3.5
+pyspark[connect]==3.5
 setuptools>=72.0.0
 websockets>=12.0

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
         "google-api-core>=2.19.1",
         "google-cloud-dataproc>=5.15.1",
         "websockets",
-        "pyspark>=3.5",
+        "pyspark[connect]>=3.5",
     ],
 )


### PR DESCRIPTION
This pulls in the required versions of the pandas and pyarrow libraries.