### PR TITLE
ci: Create a test Dockerfile and run unit tests in cloud build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*~
+.*.sw[nop]
+.DS_Store
+.idea
+/.git/

--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.10-bookworm
+
+WORKDIR /opt/tests
+# NOTE: We copy the requirements files explicitly _before_ installing
+# dependencies to allow layer caching. Afterward, we copy the rest of the build
+# sources. The intention is to reuse the preinstalled dependencies when
+# individual source files change.
+COPY requirements-dev.txt ./
+COPY requirements-test.txt ./
+RUN python3 -m pip install -U pip
+RUN python3 -m pip install --no-cache-dir -r requirements-dev.txt -r requirements-test.txt
+COPY . .
+RUN python setup.py sdist bdist_wheel egg_info
+RUN pip install .

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+  # Build a container image which bakes in a source code snapshot and built
+  # distribution artifacts.
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-container-image'
+    args: ['build', '--tag=gcr.io/${PROJECT_ID}/google-spark-connect/google-spark-connect-presubmit:${BUILD_ID}', -f, 'cloudbuild/Dockerfile', '.']
+  # Run all unit tests
+  - name: 'gcr.io/${PROJECT_ID}/google-spark-connect/google-spark-connect-presubmit:${BUILD_ID}'
+    id: 'run-unit-tests'
+    waitFor: ['build-container-image']
+    entrypoint: 'pytest'
+    args: ['-n', 'auto', 'tests/unit']
+timeout: 600s


### PR DESCRIPTION
This currently only runs unit tests, as integration tests will require some more environment plumbing. We seem to have introduced a regression in unit tests at some point, but that shouldn't block this.