### PR TITLE
Fix a connection-closing bug in the TCP-over-websocket proxy.

### DIFF
--- a/google/cloud/spark_connect/client/proxy.py
+++ b/google/cloud/spark_connect/client/proxy.py
@@ -101,6 +101,7 @@ def forward_bytes(name, from_sock, to_sock):
         try:
             bs = from_sock.recv(1024)
             if not bs:
+                to_sock.close()
                 return
             while bs:
                 try:


### PR DESCRIPTION
This change fixes a bug in the TCP-over-websocket proxy where  one end of the connection might not be closed when the other end is closed.

That, in turn, could cause messages in one direction to get dropped.