### PR TITLE
fix: Put a cap on the maximum number of retries for forwarding bytes.

### DIFF
--- a/google/cloud/spark_connect/client/proxy.py
+++ b/google/cloud/spark_connect/client/proxy.py
@@ -104,7 +104,9 @@ def forward_bytes(name, from_sock, to_sock):
             if not bs:
                 to_sock.close()
                 return
-            while bs:
+            attempt = 0
+            while bs and (attempt < 10):
+                attempt += 1
                 try:
                     to_sock.send(bs)
                     bs = None
@@ -112,6 +114,8 @@ def forward_bytes(name, from_sock, to_sock):
                     # On timeouts during a send, we retry just the send
                     # to make sure we don't lose any bytes.
                     pass
+            if bs:
+                raise Exception(f"Failed to forward bytes for {name}")
         except TimeoutError:
             # On timeouts during a receive, we retry the entire flow.
             pass


### PR DESCRIPTION
This change updates the TCP-over-websocket proxy so that it only retries sending bytes a fixed number of times (up to 10) rather than retrying indefinitely.

This resolves an issue where the attempt to close the gRPC connection would sporadically hang indefinitely.

I was able to reproduce that issue locally by manually creating a session, getting the Spark Connect URL for that session, and then running the following code in a loop:

```py
import faulthandler

from google.cloud.spark_connect.client import DataprocChannelBuilder
from pyspark.sql.connect.session import SparkSession

faulthandler.enable()
faulthandler.dump_traceback_later(30)

connect_host = '...'
connect_url = f'sc://{connect_host}:443/;use_ssl=true'
channel_builder = DataprocChannelBuilder(connect_url)

spark = SparkSession(connection=channel_builder)
spark.createDataFrame([(1, "Sarah"),(2, "Maria")]).toDF("id", "name").show()
spark.stop()
```

Without this fix I would hit the issue after only a few runs of the script.

With the fix, I was able to run the script 100 times in a row without issue.