### PR TITLE
fix: disable incorrect warning check

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -124,6 +124,9 @@ class DataprocSparkSession(SparkSession):
         def dataprocSessionConfig(self, dataproc_config: Session):
             with self._lock:
                 self._dataproc_config = dataproc_config
+                # switch to Legacy assignment policy by default
+                # https://spark.apache.org/docs/latest/sql-migration-guide.html#ddl-statements
+                dataproc_config.runtime_config.properties["spark.sql.legacy.setCommandRejectsSparkCoreConfs"] = "false"
                 for k, v in dataproc_config.runtime_config.properties.items():
                     self._options[cast(str, k)] = to_str(v)
                 return self


### PR DESCRIPTION
disable incorrect warning check by setting spark.sql.legacy.setCommandRejectsSparkCoreConfs to false

https://spark.apache.org/docs/latest/sql-migration-guide.html#ddl-statements