### PR TITLE
fix: disable incorrect warning check

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -354,6 +354,11 @@ class DataprocSparkSession(SparkSession):
                 dataproc_config = self._dataproc_config
                 for k, v in self._options.items():
                     dataproc_config.runtime_config.properties[k] = v
+            # Ensure the legacy setCommandRejectsSparkCoreConfs is always false
+            # for the Dataproc session configuration, consistent with the setting
+            # in dataprocSessionConfig. This disables an incorrect warning check.
+            # See: https://spark.apache.org/docs/latest/sql-migration-guide.html#ddl-statements
+            dataproc_config.runtime_config.properties["spark.sql.legacy.setCommandRejectsSparkCoreConfs"] = "false"
             dataproc_config.spark_connect_session = (
                 sessions.SparkConnectConfig()
             )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -109,6 +109,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
+        create_session_request.session.runtime_config.properties = {
+            "spark.sql.legacy.setCommandRejectsSparkCoreConfs": "false"
+        }
         create_session_request.session.spark_connect_session = (
             SparkConnectConfig()
         )
@@ -237,7 +240,8 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         )
         create_session_request.session.name = "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
         create_session_request.session.runtime_config.properties = {
-            "spark.executor.cores": "16"
+            "spark.executor.cores": "16",
+            "spark.sql.legacy.setCommandRejectsSparkCoreConfs": "false",
         }
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
@@ -352,6 +356,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
+        create_session_request.session.runtime_config.properties = {
+            "spark.sql.legacy.setCommandRejectsSparkCoreConfs": "false"
+        }
         create_session_request.session.spark_connect_session = (
             SparkConnectConfig()
         )
@@ -426,6 +433,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
+        create_session_request.session.runtime_config.properties = {
+            "spark.sql.legacy.setCommandRejectsSparkCoreConfs": "false"
+        }
         create_session_request.session.spark_connect_session = (
             SparkConnectConfig()
         )
@@ -508,6 +518,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
+        create_session_request.session.runtime_config.properties = {
+            "spark.sql.legacy.setCommandRejectsSparkCoreConfs": "false"
+        }
         create_session_request.session.spark_connect_session = (
             SparkConnectConfig()
         )


### PR DESCRIPTION
added config change for disabling incorrect warning check
added corresponding tests 