### PR TITLE
feat: Add default datasource config via env var

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -409,22 +409,32 @@ class DataprocSparkSession(SparkSession):
                 dataproc_config.labels["colab-notebook-kernel-id"] = os.environ[
                     "COLAB_NOTEBOOK_KERNEL_ID"
                 ]
-            default_datasource = os.getenv("DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE")
-            if default_datasource and dataproc_config.runtime_config.version >= "2.3":
-                if default_datasource.lower() == DataprocSparkSession._BIGQUERY_DATASOURCE_VALUE:
+            default_datasource = os.getenv(
+                "DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE"
+            )
+            if (
+                default_datasource
+                and dataproc_config.runtime_config.version >= "2.3"
+            ):
+                if (
+                    default_datasource.lower()
+                    == DataprocSparkSession._BIGQUERY_DATASOURCE_VALUE
+                ):
                     default_bigquery_configs = {
                         "spark.datasource.bigquery.writeMethod": "direct",
                         "spark.datasource.bigquery.viewsEnabled": "true",
                         "spark.sql.legacy.createHiveTableByDefault": "false",
                         "spark.sql.sources.default": "bigquery",
-                        "spark.sql.catalog.spark_catalog": "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog"
+                        "spark.sql.catalog.spark_catalog": "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog",
                     }
                     # Merge default configs with existing properties, user configs take precedence
                     for k, v in default_bigquery_configs.items():
                         if k not in dataproc_config.runtime_config.properties:
                             dataproc_config.runtime_config.properties[k] = v
                 else:
-                    logger.warning(f"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value: {default_datasource}. Supported value is 'bigquery'.")
+                    logger.warning(
+                        f"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value: {default_datasource}. Supported value is 'bigquery'."
+                    )
             return dataproc_config
 
         @staticmethod

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -421,7 +421,7 @@ class DataprocSparkSession(SparkSession):
                         "spark.datasource.bigquery.viewsEnabled": "true",
                         "spark.sql.legacy.createHiveTableByDefault": "false",
                         "spark.sql.sources.default": "bigquery",
-                        "spark.sql.catalog.spark_catalog": "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog",
+                        "spark.sql.catalog.spark_catalog": "com.google.cloud.spark.bigquery.BigQuerySparkSessionCatalog",
                     }
                     # Merge default configs with existing properties, user configs take precedence
                     for k, v in default_bigquery_configs.items():

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -416,15 +416,15 @@ class DataprocSparkSession(SparkSession):
                 and dataproc_config.runtime_config.version == "2.3"
             ):
                 if default_datasource == "bigquery":
-                    default_bigquery_configs = {
-                        "spark.datasource.bigquery.writeMethod": "direct",
+                    bq_datasource_properties = {
                         "spark.datasource.bigquery.viewsEnabled": "true",
+                        "spark.datasource.bigquery.writeMethod": "direct",
+                        "spark.sql.catalog.spark_catalog": "com.google.cloud.spark.bigquery.BigQuerySparkSessionCatalog",
                         "spark.sql.legacy.createHiveTableByDefault": "false",
                         "spark.sql.sources.default": "bigquery",
-                        "spark.sql.catalog.spark_catalog": "com.google.cloud.spark.bigquery.BigQuerySparkSessionCatalog",
                     }
                     # Merge default configs with existing properties, user configs take precedence
-                    for k, v in default_bigquery_configs.items():
+                    for k, v in bq_datasource_properties.items():
                         if k not in dataproc_config.runtime_config.properties:
                             dataproc_config.runtime_config.properties[k] = v
                 else:

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -68,7 +68,6 @@ class DataprocSparkSession(SparkSession):
     """
 
     _DEFAULT_RUNTIME_VERSION = "2.3"
-    _BIGQUERY_DATASOURCE_VALUE: ClassVar[str] = "bigquery"
 
     _active_s8s_session_uuid: ClassVar[Optional[str]] = None
     _project_id = None
@@ -414,12 +413,9 @@ class DataprocSparkSession(SparkSession):
             )
             if (
                 default_datasource
-                and dataproc_config.runtime_config.version >= "2.3"
+                and dataproc_config.runtime_config.version == "2.3"
             ):
-                if (
-                    default_datasource.lower()
-                    == DataprocSparkSession._BIGQUERY_DATASOURCE_VALUE
-                ):
+                if default_datasource == "bigquery":
                     default_bigquery_configs = {
                         "spark.datasource.bigquery.writeMethod": "direct",
                         "spark.datasource.bigquery.viewsEnabled": "true",
@@ -433,7 +429,8 @@ class DataprocSparkSession(SparkSession):
                             dataproc_config.runtime_config.properties[k] = v
                 else:
                     logger.warning(
-                        f"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value: {default_datasource}. Supported value is 'bigquery'."
+                        f"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value:"
+                        f" {default_datasource}. Supported value is 'bigquery'."
                     )
             return dataproc_config
 

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -410,7 +410,7 @@ class DataprocSparkSession(SparkSession):
                     "COLAB_NOTEBOOK_KERNEL_ID"
                 ]
             default_datasource = os.getenv("DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE")
-            if default_datasource:
+            if default_datasource and dataproc_config.runtime_config.version >= "2.3":
                 if default_datasource.lower() == DataprocSparkSession._BIGQUERY_DATASOURCE_VALUE:
                     default_bigquery_configs = {
                         "spark.datasource.bigquery.writeMethod": "direct",

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -68,6 +68,7 @@ class DataprocSparkSession(SparkSession):
     """
 
     _DEFAULT_RUNTIME_VERSION = "2.3"
+    _BIGQUERY_DATASOURCE_VALUE: ClassVar[str] = "bigquery"
 
     _active_s8s_session_uuid: ClassVar[Optional[str]] = None
     _project_id = None
@@ -410,7 +411,7 @@ class DataprocSparkSession(SparkSession):
                 ]
             default_datasource = os.getenv("DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE")
             if default_datasource:
-                if default_datasource.lower() == "bigquery":
+                if default_datasource.lower() == DataprocSparkSession._BIGQUERY_DATASOURCE_VALUE:
                     default_bigquery_configs = {
                         "spark.datasource.bigquery.writeMethod": "direct",
                         "spark.datasource.bigquery.viewsEnabled": "true",

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -408,6 +408,22 @@ class DataprocSparkSession(SparkSession):
                 dataproc_config.labels["colab-notebook-kernel-id"] = os.environ[
                     "COLAB_NOTEBOOK_KERNEL_ID"
                 ]
+            default_datasource = os.getenv("DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE")
+            if default_datasource:
+                if default_datasource.lower() == "bigquery":
+                    default_bigquery_configs = {
+                        "spark.datasource.bigquery.writeMethod": "direct",
+                        "spark.datasource.bigquery.viewsEnabled": "true",
+                        "spark.sql.legacy.createHiveTableByDefault": "false",
+                        "spark.sql.sources.default": "bigquery",
+                        "spark.sql.catalog.spark_catalog": "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog"
+                    }
+                    # Merge default configs with existing properties, user configs take precedence
+                    for k, v in default_bigquery_configs.items():
+                        if k not in dataproc_config.runtime_config.properties:
+                            dataproc_config.runtime_config.properties[k] = v
+                else:
+                    logger.warning(f"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value: {default_datasource}. Supported value is 'bigquery'.")
             return dataproc_config
 
         @staticmethod

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -849,7 +849,6 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
                 [mock.call(get_session_request), mock.call(get_session_request)]
             )
 
-
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
     @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")
@@ -859,10 +858,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
     )
-    @mock.patch("google.cloud.dataproc_spark_connect.session.logger") # Mock the logger
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.logger"
+    )  # Mock the logger
     def test_create_session_with_default_datasource_env_var(
         self,
-        mock_logger, # Add mock logger parameter
+        mock_logger,  # Add mock logger parameter
         mock_is_s8s_session_active,
         mock_dataproc_session_id,
         mock_client_config,
@@ -874,7 +875,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         mock_session_controller_client_instance = (
             mock_session_controller_client.return_value
         )
-        mock_dataproc_session_id.return_value = "c002e4ef-fe5e-41a8-a157-160aa73e4f7f" # Use a valid UUID
+        mock_dataproc_session_id.return_value = (
+            "c002e4ef-fe5e-41a8-a157-160aa73e4f7f"  # Use a valid UUID
+        )
         mock_client_config.return_value = ConfigResult.fromProto(
             ConfigResponse()
         )
@@ -886,8 +889,17 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         session_response.runtime_info.endpoints = {
             "Spark Connect Server": "sc://spark-connect-server.example.com:443"
         }
-        session_response.uuid = "c002e4ef-fe5e-41a8-a157-160aa73e4f7f" # Use a valid UUID
-        mock_operation.result.side_effect = [session_response, session_response, session_response, session_response, session_response, session_response] # Provide a response for each getOrCreate call
+        session_response.uuid = (
+            "c002e4ef-fe5e-41a8-a157-160aa73e4f7f"  # Use a valid UUID
+        )
+        mock_operation.result.side_effect = [
+            session_response,
+            session_response,
+            session_response,
+            session_response,
+            session_response,
+            session_response,
+        ]  # Provide a response for each getOrCreate call
         mock_session_controller_client_instance.create_session.return_value = (
             mock_operation
         )
@@ -897,105 +909,264 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             session = DataprocSparkSession.builder.getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
-            self.assertNotIn("spark.datasource.bigquery.writeMethod", create_session_request.session.runtime_config.properties)
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
+            self.assertNotIn(
+                "spark.datasource.bigquery.writeMethod",
+                create_session_request.session.runtime_config.properties,
+            )
             mock_logger.warning.assert_not_called()
             self.stopSession(mock_session_controller_client_instance, session)
             mock_session_controller_client_instance.create_session.reset_mock()
             mock_logger.warning.reset_mock()
 
-
         # Scenario 2: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to "bigquery"
-        with mock.patch.dict(os.environ, {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"}, clear=True):
+        with mock.patch.dict(
+            os.environ,
+            {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"},
+            clear=True,
+        ):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             session = DataprocSparkSession.builder.getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             # With runtime version >= 2.3, the BigQuery properties should be set
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.writeMethod"), "direct")
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.viewsEnabled"), "true")
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.legacy.createHiveTableByDefault"), "false")
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.sources.default"), "bigquery")
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.catalog.spark_catalog"), "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog")
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.datasource.bigquery.writeMethod"
+                ),
+                "direct",
+            )
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.datasource.bigquery.viewsEnabled"
+                ),
+                "true",
+            )
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.sql.legacy.createHiveTableByDefault"
+                ),
+                "false",
+            )
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.sql.sources.default"
+                ),
+                "bigquery",
+            )
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.sql.catalog.spark_catalog"
+                ),
+                "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog",
+            )
             mock_logger.warning.assert_not_called()
             self.stopSession(mock_session_controller_client_instance, session)
             mock_session_controller_client_instance.create_session.reset_mock()
             mock_logger.warning.reset_mock()
 
         # Scenario 3: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to "bigquery" and runtime version is "2.2"
-        with mock.patch.dict(os.environ, {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"}, clear=True):
+        with mock.patch.dict(
+            os.environ,
+            {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"},
+            clear=True,
+        ):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             dataproc_config = Session()
-            dataproc_config.runtime_config.version = "2.2" # Set runtime version to "2.2"
-            session = DataprocSparkSession.builder.dataprocSessionConfig(dataproc_config).getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
+            dataproc_config.runtime_config.version = (
+                "2.2"  # Set runtime version to "2.2"
+            )
+            session = DataprocSparkSession.builder.dataprocSessionConfig(
+                dataproc_config
+            ).getOrCreate()
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             # With runtime version 2.2, the BigQuery properties should NOT be set
-            self.assertNotIn("spark.datasource.bigquery.writeMethod", create_session_request.session.runtime_config.properties)
-            self.assertNotIn("spark.datasource.bigquery.viewsEnabled", create_session_request.session.runtime_config.properties)
-            self.assertNotIn("spark.sql.legacy.createHiveTableByDefault", create_session_request.session.runtime_config.properties)
-            self.assertNotIn("spark.sql.sources.default", create_session_request.session.runtime_config.properties)
-            self.assertNotIn("spark.sql.catalog.spark_catalog", create_session_request.session.runtime_config.properties)
+            self.assertNotIn(
+                "spark.datasource.bigquery.writeMethod",
+                create_session_request.session.runtime_config.properties,
+            )
+            self.assertNotIn(
+                "spark.datasource.bigquery.viewsEnabled",
+                create_session_request.session.runtime_config.properties,
+            )
+            self.assertNotIn(
+                "spark.sql.legacy.createHiveTableByDefault",
+                create_session_request.session.runtime_config.properties,
+            )
+            self.assertNotIn(
+                "spark.sql.sources.default",
+                create_session_request.session.runtime_config.properties,
+            )
+            self.assertNotIn(
+                "spark.sql.catalog.spark_catalog",
+                create_session_request.session.runtime_config.properties,
+            )
             mock_logger.warning.assert_not_called()
             self.stopSession(mock_session_controller_client_instance, session)
             mock_session_controller_client_instance.create_session.reset_mock()
             mock_logger.warning.reset_mock()
 
         # Scenario 4: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to "bigquery" and runtime version is > "2.3"
-        with mock.patch.dict(os.environ, {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"}, clear=True):
+        with mock.patch.dict(
+            os.environ,
+            {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"},
+            clear=True,
+        ):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             dataproc_config = Session()
-            dataproc_config.runtime_config.version = "2.4" # Set runtime version > "2.3"
-            session = DataprocSparkSession.builder.dataprocSessionConfig(dataproc_config).getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
+            dataproc_config.runtime_config.version = (
+                "2.4"  # Set runtime version > "2.3"
+            )
+            session = DataprocSparkSession.builder.dataprocSessionConfig(
+                dataproc_config
+            ).getOrCreate()
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             # With runtime version > 2.3, the BigQuery properties should be set
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.writeMethod"), "direct")
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.viewsEnabled"), "true")
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.legacy.createHiveTableByDefault"), "false")
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.sources.default"), "bigquery")
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.catalog.spark_catalog"), "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog")
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.datasource.bigquery.writeMethod"
+                ),
+                "direct",
+            )
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.datasource.bigquery.viewsEnabled"
+                ),
+                "true",
+            )
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.sql.legacy.createHiveTableByDefault"
+                ),
+                "false",
+            )
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.sql.sources.default"
+                ),
+                "bigquery",
+            )
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.sql.catalog.spark_catalog"
+                ),
+                "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog",
+            )
             mock_logger.warning.assert_not_called()
             self.stopSession(mock_session_controller_client_instance, session)
             mock_session_controller_client_instance.create_session.reset_mock()
             mock_logger.warning.reset_mock()
 
         # Scenario 5: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value
-        with mock.patch.dict(os.environ, {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "invalid_datasource"}, clear=True):
+        with mock.patch.dict(
+            os.environ,
+            {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "invalid_datasource"},
+            clear=True,
+        ):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             session = DataprocSparkSession.builder.getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
-            self.assertNotIn("spark.datasource.bigquery.writeMethod", create_session_request.session.runtime_config.properties)
-            mock_logger.warning.assert_called_once_with("DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value: invalid_datasource. Supported value is 'bigquery'.")
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
+            self.assertNotIn(
+                "spark.datasource.bigquery.writeMethod",
+                create_session_request.session.runtime_config.properties,
+            )
+            mock_logger.warning.assert_called_once_with(
+                "DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value: invalid_datasource. Supported value is 'bigquery'."
+            )
             self.stopSession(mock_session_controller_client_instance, session)
             mock_session_controller_client_instance.create_session.reset_mock()
             mock_logger.warning.reset_mock()
 
         # Scenario 6: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to "bigquery" with pre-existing properties and runtime version > "2.3"
-        with mock.patch.dict(os.environ, {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"}, clear=True):
+        with mock.patch.dict(
+            os.environ,
+            {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"},
+            clear=True,
+        ):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             dataproc_config = Session()
-            dataproc_config.runtime_config.version = "2.4" # Set runtime version > "2.3"
+            dataproc_config.runtime_config.version = (
+                "2.4"  # Set runtime version > "2.3"
+            )
             dataproc_config.runtime_config.properties = {
                 "spark.datasource.bigquery.writeMethod": "override_method",
-                "spark.some.other.property": "some_value"
+                "spark.some.other.property": "some_value",
             }
-            session = DataprocSparkSession.builder.dataprocSessionConfig(dataproc_config).getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
+            session = DataprocSparkSession.builder.dataprocSessionConfig(
+                dataproc_config
+            ).getOrCreate()
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             # With runtime version > 2.3, the BigQuery default properties should be set,
             # but pre-existing properties should override defaults.
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.writeMethod"), "override_method") # Pre-existing property remains
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.viewsEnabled"), "true") # Default should still be set
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.legacy.createHiveTableByDefault"), "false") # Default should still be set
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.sources.default"), "bigquery") # Default should still be set
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.catalog.spark_catalog"), "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog") # Default should still be set
-            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.some.other.property"), "some_value") # Existing property should remain
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.datasource.bigquery.writeMethod"
+                ),
+                "override_method",
+            )  # Pre-existing property remains
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.datasource.bigquery.viewsEnabled"
+                ),
+                "true",
+            )  # Default should still be set
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.sql.legacy.createHiveTableByDefault"
+                ),
+                "false",
+            )  # Default should still be set
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.sql.sources.default"
+                ),
+                "bigquery",
+            )  # Default should still be set
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.sql.catalog.spark_catalog"
+                ),
+                "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog",
+            )  # Default should still be set
+            self.assertEqual(
+                create_session_request.session.runtime_config.properties.get(
+                    "spark.some.other.property"
+                ),
+                "some_value",
+            )  # Existing property should remain
             mock_logger.warning.assert_not_called()
             self.stopSession(mock_session_controller_client_instance, session)
             mock_session_controller_client_instance.create_session.reset_mock()
             mock_logger.warning.reset_mock()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -937,7 +937,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             ][
                 0
             ]
-            # With runtime version >= 2.3, the BigQuery properties should be set
+            # With runtime version 2.3, the BigQuery properties should be set
             self.assertEqual(
                 create_session_request.session.runtime_config.properties.get(
                     "spark.datasource.bigquery.writeMethod"
@@ -1019,7 +1019,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             mock_session_controller_client_instance.create_session.reset_mock()
             mock_logger.warning.reset_mock()
 
-        # Scenario 4: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to "bigquery" and runtime version is > "2.3"
+        # Scenario 4: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to "bigquery" and runtime version is "2.3"
         with mock.patch.dict(
             os.environ,
             {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"},
@@ -1028,9 +1028,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             dataproc_config = Session()
-            dataproc_config.runtime_config.version = (
-                "2.4"  # Set runtime version > "2.3"
-            )
+            dataproc_config.runtime_config.version = "2.3"
             session = DataprocSparkSession.builder.dataprocSessionConfig(
                 dataproc_config
             ).getOrCreate()
@@ -1109,9 +1107,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             dataproc_config = Session()
-            dataproc_config.runtime_config.version = (
-                "2.4"  # Set runtime version > "2.3"
-            )
+            dataproc_config.runtime_config.version = "2.3"
             dataproc_config.runtime_config.properties = {
                 "spark.datasource.bigquery.writeMethod": "override_method",
                 "spark.some.other.property": "some_value",
@@ -1124,7 +1120,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             ][
                 0
             ]
-            # With runtime version > 2.3, the BigQuery default properties should be set,
+            # With runtime version 2.3, the BigQuery default properties should be set,
             # but pre-existing properties should override defaults.
             self.assertEqual(
                 create_session_request.session.runtime_config.properties.get(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -966,7 +966,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
                 create_session_request.session.runtime_config.properties.get(
                     "spark.sql.catalog.spark_catalog"
                 ),
-                "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog",
+                "com.google.cloud.spark.bigquery.BigQuerySparkSessionCatalog",
             )
             mock_logger.warning.assert_not_called()
             self.stopSession(mock_session_controller_client_instance, session)
@@ -1066,7 +1066,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
                 create_session_request.session.runtime_config.properties.get(
                     "spark.sql.catalog.spark_catalog"
                 ),
-                "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog",
+                "com.google.cloud.spark.bigquery.BigQuerySparkSessionCatalog",
             )
             mock_logger.warning.assert_not_called()
             self.stopSession(mock_session_controller_client_instance, session)
@@ -1150,7 +1150,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
                 create_session_request.session.runtime_config.properties.get(
                     "spark.sql.catalog.spark_catalog"
                 ),
-                "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog",
+                "com.google.cloud.spark.bigquery.BigQuerySparkSessionCatalog",
             )  # Default should still be set
             self.assertEqual(
                 create_session_request.session.runtime_config.properties.get(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -850,5 +850,107 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             )
 
 
+    @mock.patch("google.auth.default")
+    @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
+    @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
+    )
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.logger") # Mock the logger
+    def test_create_session_with_default_datasource_env_var(
+        self,
+        mock_logger, # Add mock logger parameter
+        mock_is_s8s_session_active,
+        mock_dataproc_session_id,
+        mock_client_config,
+        mock_session_controller_client,
+        mock_credentials,
+    ):
+        session = None
+        mock_is_s8s_session_active.return_value = True
+        mock_session_controller_client_instance = (
+            mock_session_controller_client.return_value
+        )
+        mock_dataproc_session_id.return_value = "c002e4ef-fe5e-41a8-a157-160aa73e4f7f" # Use a valid UUID
+        mock_client_config.return_value = ConfigResult.fromProto(
+            ConfigResponse()
+        )
+        cred = mock.MagicMock()
+        cred.token = "token"
+        mock_credentials.return_value = (cred, "")
+        mock_operation = mock.Mock()
+        session_response = Session()
+        session_response.runtime_info.endpoints = {
+            "Spark Connect Server": "sc://spark-connect-server.example.com:443"
+        }
+        session_response.uuid = "c002e4ef-fe5e-41a8-a157-160aa73e4f7f" # Use a valid UUID
+        mock_operation.result.side_effect = [session_response, session_response, session_response, session_response] # Provide a response for each getOrCreate call
+        mock_session_controller_client_instance.create_session.return_value = (
+            mock_operation
+        )
+
+        # Scenario 1: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is not set
+        with mock.patch.dict(os.environ, {}, clear=True):
+            os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
+            os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
+            session = DataprocSparkSession.builder.getOrCreate()
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
+            self.assertNotIn("spark.datasource.bigquery.writeMethod", create_session_request.session.runtime_config.properties)
+            mock_logger.warning.assert_not_called()
+            self.stopSession(mock_session_controller_client_instance, session)
+            mock_session_controller_client_instance.create_session.reset_mock()
+            mock_logger.warning.reset_mock()
+
+
+        # Scenario 2: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to "bigquery"
+        with mock.patch.dict(os.environ, {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"}, clear=True):
+            os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
+            os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
+            session = DataprocSparkSession.builder.getOrCreate()
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
+            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.writeMethod"), "direct")
+            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.viewsEnabled"), "true")
+            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.legacy.createHiveTableByDefault"), "false")
+            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.sources.default"), "bigquery")
+            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.sql.catalog.spark_catalog"), "com.google.cloud.spark.bigquery.BigLakeMetastoreSparkCatalog")
+            mock_logger.warning.assert_not_called()
+            self.stopSession(mock_session_controller_client_instance, session)
+            mock_session_controller_client_instance.create_session.reset_mock()
+            mock_logger.warning.reset_mock()
+
+        # Scenario 3: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value
+        with mock.patch.dict(os.environ, {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "invalid_datasource"}, clear=True):
+            os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
+            os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
+            session = DataprocSparkSession.builder.getOrCreate()
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
+            self.assertNotIn("spark.datasource.bigquery.writeMethod", create_session_request.session.runtime_config.properties)
+            mock_logger.warning.assert_called_once_with("DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value: invalid_datasource. Supported value is 'bigquery'.")
+            self.stopSession(mock_session_controller_client_instance, session)
+            mock_session_controller_client_instance.create_session.reset_mock()
+            mock_logger.warning.reset_mock()
+
+        # Scenario 4: DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to "bigquery" with pre-existing properties
+        with mock.patch.dict(os.environ, {"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE": "bigquery"}, clear=True):
+            os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
+            os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
+            dataproc_config = Session()
+            dataproc_config.runtime_config.properties = {
+                "spark.datasource.bigquery.writeMethod": "override_method",
+                "spark.some.other.property": "some_value"
+            }
+            session = DataprocSparkSession.builder.dataprocSessionConfig(dataproc_config).getOrCreate()
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[0][0]
+            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.writeMethod"), "override_method")
+            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.datasource.bigquery.viewsEnabled"), "true") # Default should still be set
+            self.assertEqual(create_session_request.session.runtime_config.properties.get("spark.some.other.property"), "some_value") # Existing property should remain
+            mock_logger.warning.assert_not_called()
+            self.stopSession(mock_session_controller_client_instance, session)
+            mock_session_controller_client_instance.create_session.reset_mock()
+            mock_logger.warning.reset_mock()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This commit introduces the ability to configure the default datasource for Dataproc Spark Connect sessions using the `DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE` environment variable.

When set to "bigquery", it automatically configures the session with optimized BigQuery settings, including write method, views enabled, and default catalog. This simplifies BigQuery integration and improves the user experience.

A warning message is logged if the environment variable is set to an unsupported value. Unit tests are added to verify the functionality.