### PR TITLE
chore: Add VS Code to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*.sw[nop]
 .idea
 .DS_Store
+.vscode
 __pycache__
 build/
 dist/


### PR DESCRIPTION
This commit adds the `.vscode` directory to the `.gitignore` file. This prevents VS Code's settings and workspace files from being accidentally committed to the repository.