### PR TITLE
feat: Add colab-notebook-id label to Dataproc Spark Connect session

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -150,16 +150,16 @@ class DataprocSparkSession(SparkSession):
         def __create_spark_connect_session_from_s8s(
             self, session_response, session_name
         ) -> "DataprocSparkSession":
-            DataprocSparkSession._active_s8s_session_uuid = session_response.uuid
+            DataprocSparkSession._active_s8s_session_uuid = (
+                session_response.uuid
+            )
             DataprocSparkSession._project_id = self._project_id
             DataprocSparkSession._region = self._region
             DataprocSparkSession._client_options = self._client_options
             spark_connect_url = session_response.runtime_info.endpoints.get(
                 "Spark Connect Server"
             )
-            url = (
-                f"{spark_connect_url}/;session_id={session_response.uuid};use_ssl=true"
-            )
+            url = f"{spark_connect_url}/;session_id={session_response.uuid};use_ssl=true"
             logger.debug(f"Spark Connect URL: {url}")
             self._channel_builder = DataprocChannelBuilder(
                 url,
@@ -189,7 +189,9 @@ class DataprocSparkSession(SparkSession):
 
                 session_id = self.generate_dataproc_session_id()
                 dataproc_config.name = f"projects/{self._project_id}/locations/{self._region}/sessions/{session_id}"
-                logger.debug(f"Dataproc Session configuration:\n{dataproc_config}")
+                logger.debug(
+                    f"Dataproc Session configuration:\n{dataproc_config}"
+                )
 
                 session_request = CreateSessionRequest()
                 session_request.session_id = session_id
@@ -265,14 +267,18 @@ class DataprocSparkSession(SparkSession):
                     stop_create_session_pbar_event.set()
                     create_session_pbar_thread.join()
                     print("Dataproc Session was successfully created")
-                    file_path = DataprocSparkSession._get_active_session_file_path()
+                    file_path = (
+                        DataprocSparkSession._get_active_session_file_path()
+                    )
                     if file_path is not None:
                         try:
                             session_data = {
                                 "session_name": session_response.name,
                                 "session_uuid": session_response.uuid,
                             }
-                            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                            os.makedirs(
+                                os.path.dirname(file_path), exist_ok=True
+                            )
                             with open(file_path, "w") as json_file:
                                 json.dump(session_data, json_file, indent=4)
                         except Exception as e:
@@ -292,7 +298,9 @@ class DataprocSparkSession(SparkSession):
                     if create_session_pbar_thread.is_alive():
                         create_session_pbar_thread.join()
                     DataprocSparkSession._active_s8s_session_id = None
-                    raise RuntimeError(f"Error while creating Dataproc Session") from e
+                    raise RuntimeError(
+                        f"Error while creating Dataproc Session"
+                    ) from e
                 finally:
                     stop_create_session_pbar_event.set()
 
@@ -352,7 +360,9 @@ class DataprocSparkSession(SparkSession):
                 dataproc_config = self._dataproc_config
                 for k, v in self._options.items():
                     dataproc_config.runtime_config.properties[k] = v
-            dataproc_config.spark_connect_session = sessions.SparkConnectConfig()
+            dataproc_config.spark_connect_session = (
+                sessions.SparkConnectConfig()
+            )
             if not dataproc_config.runtime_config.version:
                 dataproc_config.runtime_config.version = (
                     DataprocSparkSession._DEFAULT_RUNTIME_VERSION
@@ -368,40 +378,49 @@ class DataprocSparkSession(SparkSession):
                 not dataproc_config.environment_config.execution_config.service_account
                 and "DATAPROC_SPARK_CONNECT_SERVICE_ACCOUNT" in os.environ
             ):
-                dataproc_config.environment_config.execution_config.service_account = (
-                    os.getenv("DATAPROC_SPARK_CONNECT_SERVICE_ACCOUNT")
+                dataproc_config.environment_config.execution_config.service_account = os.getenv(
+                    "DATAPROC_SPARK_CONNECT_SERVICE_ACCOUNT"
                 )
             if (
                 not dataproc_config.environment_config.execution_config.subnetwork_uri
                 and "DATAPROC_SPARK_CONNECT_SUBNET" in os.environ
             ):
-                dataproc_config.environment_config.execution_config.subnetwork_uri = (
-                    os.getenv("DATAPROC_SPARK_CONNECT_SUBNET")
+                dataproc_config.environment_config.execution_config.subnetwork_uri = os.getenv(
+                    "DATAPROC_SPARK_CONNECT_SUBNET"
                 )
             if (
                 not dataproc_config.environment_config.execution_config.ttl
                 and "DATAPROC_SPARK_CONNECT_TTL_SECONDS" in os.environ
             ):
                 dataproc_config.environment_config.execution_config.ttl = {
-                    "seconds": int(os.getenv("DATAPROC_SPARK_CONNECT_TTL_SECONDS"))
+                    "seconds": int(
+                        os.getenv("DATAPROC_SPARK_CONNECT_TTL_SECONDS")
+                    )
                 }
             if (
                 not dataproc_config.environment_config.execution_config.idle_ttl
                 and "DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS" in os.environ
             ):
                 dataproc_config.environment_config.execution_config.idle_ttl = {
-                    "seconds": int(os.getenv("DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS"))
+                    "seconds": int(
+                        os.getenv("DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS")
+                    )
                 }
             if "COLAB_NOTEBOOK_RUNTIME_ID" in os.environ:
-                dataproc_config.labels["colab-notebook-runtime-id"] = os.environ[
-                    "COLAB_NOTEBOOK_RUNTIME_ID"
-                ]
+                dataproc_config.labels["colab-notebook-runtime-id"] = (
+                    os.environ["COLAB_NOTEBOOK_RUNTIME_ID"]
+                )
             if "COLAB_NOTEBOOK_KERNEL_ID" in os.environ:
                 dataproc_config.labels["colab-notebook-kernel-id"] = os.environ[
                     "COLAB_NOTEBOOK_KERNEL_ID"
                 ]
-            default_datasource = os.getenv("DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE")
-            if default_datasource and dataproc_config.runtime_config.version == "2.3":
+            default_datasource = os.getenv(
+                "DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE"
+            )
+            if (
+                default_datasource
+                and dataproc_config.runtime_config.version == "2.3"
+            ):
                 if default_datasource == "bigquery":
                     bq_datasource_properties = {
                         "spark.datasource.bigquery.viewsEnabled": "true",
@@ -430,7 +449,9 @@ class DataprocSparkSession(SparkSession):
             timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
             suffix_length = 6
             random_suffix = "".join(
-                random.choices(string.ascii_lowercase + string.digits, k=suffix_length)
+                random.choices(
+                    string.ascii_lowercase + string.digits, k=suffix_length
+                )
             )
             return f"sc-{timestamp}-{random_suffix}"
 
@@ -514,7 +535,9 @@ class DataprocSparkSession(SparkSession):
                 file=True,
             )
         else:
-            super().addArtifacts(*artifact, pyfile=pyfile, archive=archive, file=file)
+            super().addArtifacts(
+                *artifact, pyfile=pyfile, archive=archive, file=file
+            )
 
     @staticmethod
     def _get_active_session_file_path():
@@ -540,7 +563,9 @@ class DataprocSparkSession(SparkSession):
             self.client.close()
             if self is DataprocSparkSession._default_session:
                 DataprocSparkSession._default_session = None
-            if self is getattr(DataprocSparkSession._active_session, "session", None):
+            if self is getattr(
+                DataprocSparkSession._active_session, "session", None
+            ):
                 DataprocSparkSession._active_session.session = None
 
 
@@ -551,9 +576,7 @@ def terminate_s8s_session(
 
     logger.debug(f"Terminating Dataproc Session: {active_s8s_session_id}")
     terminate_session_request = TerminateSessionRequest()
-    session_name = (
-        f"projects/{project_id}/locations/{region}/sessions/{active_s8s_session_id}"
-    )
+    session_name = f"projects/{project_id}/locations/{region}/sessions/{active_s8s_session_id}"
     terminate_session_request.name = session_name
     state = None
     try:
@@ -571,7 +594,9 @@ def terminate_s8s_session(
             state = session.state
             time.sleep(1)
     except NotFound:
-        logger.debug(f"{active_s8s_session_id} Dataproc Session already deleted")
+        logger.debug(
+            f"{active_s8s_session_id} Dataproc Session already deleted"
+        )
     # Client will get 'Aborted' error if session creation is still in progress and
     # 'FailedPrecondition' if another termination is still in progress.
     # Both are retryable, but we catch it and let TTL take care of cleanups.

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -25,7 +25,13 @@ import tqdm
 
 from google.api_core import retry
 from google.api_core.client_options import ClientOptions
-from google.api_core.exceptions import Aborted, FailedPrecondition, InvalidArgument, NotFound, PermissionDenied
+from google.api_core.exceptions import (
+    Aborted,
+    FailedPrecondition,
+    InvalidArgument,
+    NotFound,
+    PermissionDenied,
+)
 from google.api_core.future.polling import POLLING_PREDICATE
 from google.cloud.dataproc_spark_connect.client import DataprocChannelBuilder
 from google.cloud.dataproc_spark_connect.exceptions import DataprocSparkConnectException
@@ -144,16 +150,16 @@ class DataprocSparkSession(SparkSession):
         def __create_spark_connect_session_from_s8s(
             self, session_response, session_name
         ) -> "DataprocSparkSession":
-            DataprocSparkSession._active_s8s_session_uuid = (
-                session_response.uuid
-            )
+            DataprocSparkSession._active_s8s_session_uuid = session_response.uuid
             DataprocSparkSession._project_id = self._project_id
             DataprocSparkSession._region = self._region
             DataprocSparkSession._client_options = self._client_options
             spark_connect_url = session_response.runtime_info.endpoints.get(
                 "Spark Connect Server"
             )
-            url = f"{spark_connect_url}/;session_id={session_response.uuid};use_ssl=true"
+            url = (
+                f"{spark_connect_url}/;session_id={session_response.uuid};use_ssl=true"
+            )
             logger.debug(f"Spark Connect URL: {url}")
             self._channel_builder = DataprocChannelBuilder(
                 url,
@@ -183,9 +189,7 @@ class DataprocSparkSession(SparkSession):
 
                 session_id = self.generate_dataproc_session_id()
                 dataproc_config.name = f"projects/{self._project_id}/locations/{self._region}/sessions/{session_id}"
-                logger.debug(
-                    f"Dataproc Session configuration:\n{dataproc_config}"
-                )
+                logger.debug(f"Dataproc Session configuration:\n{dataproc_config}")
 
                 session_request = CreateSessionRequest()
                 session_request.session_id = session_id
@@ -261,18 +265,14 @@ class DataprocSparkSession(SparkSession):
                     stop_create_session_pbar_event.set()
                     create_session_pbar_thread.join()
                     print("Dataproc Session was successfully created")
-                    file_path = (
-                        DataprocSparkSession._get_active_session_file_path()
-                    )
+                    file_path = DataprocSparkSession._get_active_session_file_path()
                     if file_path is not None:
                         try:
                             session_data = {
                                 "session_name": session_response.name,
                                 "session_uuid": session_response.uuid,
                             }
-                            os.makedirs(
-                                os.path.dirname(file_path), exist_ok=True
-                            )
+                            os.makedirs(os.path.dirname(file_path), exist_ok=True)
                             with open(file_path, "w") as json_file:
                                 json.dump(session_data, json_file, indent=4)
                         except Exception as e:
@@ -292,9 +292,7 @@ class DataprocSparkSession(SparkSession):
                     if create_session_pbar_thread.is_alive():
                         create_session_pbar_thread.join()
                     DataprocSparkSession._active_s8s_session_id = None
-                    raise RuntimeError(
-                        f"Error while creating Dataproc Session"
-                    ) from e
+                    raise RuntimeError(f"Error while creating Dataproc Session") from e
                 finally:
                     stop_create_session_pbar_event.set()
 
@@ -354,9 +352,7 @@ class DataprocSparkSession(SparkSession):
                 dataproc_config = self._dataproc_config
                 for k, v in self._options.items():
                     dataproc_config.runtime_config.properties[k] = v
-            dataproc_config.spark_connect_session = (
-                sessions.SparkConnectConfig()
-            )
+            dataproc_config.spark_connect_session = sessions.SparkConnectConfig()
             if not dataproc_config.runtime_config.version:
                 dataproc_config.runtime_config.version = (
                     DataprocSparkSession._DEFAULT_RUNTIME_VERSION
@@ -372,49 +368,40 @@ class DataprocSparkSession(SparkSession):
                 not dataproc_config.environment_config.execution_config.service_account
                 and "DATAPROC_SPARK_CONNECT_SERVICE_ACCOUNT" in os.environ
             ):
-                dataproc_config.environment_config.execution_config.service_account = os.getenv(
-                    "DATAPROC_SPARK_CONNECT_SERVICE_ACCOUNT"
+                dataproc_config.environment_config.execution_config.service_account = (
+                    os.getenv("DATAPROC_SPARK_CONNECT_SERVICE_ACCOUNT")
                 )
             if (
                 not dataproc_config.environment_config.execution_config.subnetwork_uri
                 and "DATAPROC_SPARK_CONNECT_SUBNET" in os.environ
             ):
-                dataproc_config.environment_config.execution_config.subnetwork_uri = os.getenv(
-                    "DATAPROC_SPARK_CONNECT_SUBNET"
+                dataproc_config.environment_config.execution_config.subnetwork_uri = (
+                    os.getenv("DATAPROC_SPARK_CONNECT_SUBNET")
                 )
             if (
                 not dataproc_config.environment_config.execution_config.ttl
                 and "DATAPROC_SPARK_CONNECT_TTL_SECONDS" in os.environ
             ):
                 dataproc_config.environment_config.execution_config.ttl = {
-                    "seconds": int(
-                        os.getenv("DATAPROC_SPARK_CONNECT_TTL_SECONDS")
-                    )
+                    "seconds": int(os.getenv("DATAPROC_SPARK_CONNECT_TTL_SECONDS"))
                 }
             if (
                 not dataproc_config.environment_config.execution_config.idle_ttl
                 and "DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS" in os.environ
             ):
                 dataproc_config.environment_config.execution_config.idle_ttl = {
-                    "seconds": int(
-                        os.getenv("DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS")
-                    )
+                    "seconds": int(os.getenv("DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS"))
                 }
             if "COLAB_NOTEBOOK_RUNTIME_ID" in os.environ:
-                dataproc_config.labels["colab-notebook-runtime-id"] = (
-                    os.environ["COLAB_NOTEBOOK_RUNTIME_ID"]
-                )
+                dataproc_config.labels["colab-notebook-runtime-id"] = os.environ[
+                    "COLAB_NOTEBOOK_RUNTIME_ID"
+                ]
             if "COLAB_NOTEBOOK_KERNEL_ID" in os.environ:
                 dataproc_config.labels["colab-notebook-kernel-id"] = os.environ[
                     "COLAB_NOTEBOOK_KERNEL_ID"
                 ]
-            default_datasource = os.getenv(
-                "DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE"
-            )
-            if (
-                default_datasource
-                and dataproc_config.runtime_config.version == "2.3"
-            ):
+            default_datasource = os.getenv("DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE")
+            if default_datasource and dataproc_config.runtime_config.version == "2.3":
                 if default_datasource == "bigquery":
                     bq_datasource_properties = {
                         "spark.datasource.bigquery.viewsEnabled": "true",
@@ -433,9 +420,9 @@ class DataprocSparkSession(SparkSession):
                         f" {default_datasource}. Supported value is 'bigquery'."
                     )
             if "COLAB_NOTEBOOK_ID" in os.environ:
-                dataproc_config.labels["colab-notebook-id"] = (
-                    os.environ["COLAB_NOTEBOOK_ID"]
-                )
+                dataproc_config.labels["colab-notebook-id"] = os.environ[
+                    "COLAB_NOTEBOOK_ID"
+                ]
             return dataproc_config
 
         @staticmethod
@@ -443,9 +430,7 @@ class DataprocSparkSession(SparkSession):
             timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
             suffix_length = 6
             random_suffix = "".join(
-                random.choices(
-                    string.ascii_lowercase + string.digits, k=suffix_length
-                )
+                random.choices(string.ascii_lowercase + string.digits, k=suffix_length)
             )
             return f"sc-{timestamp}-{random_suffix}"
 
@@ -529,9 +514,7 @@ class DataprocSparkSession(SparkSession):
                 file=True,
             )
         else:
-            super().addArtifacts(
-                *artifact, pyfile=pyfile, archive=archive, file=file
-            )
+            super().addArtifacts(*artifact, pyfile=pyfile, archive=archive, file=file)
 
     @staticmethod
     def _get_active_session_file_path():
@@ -557,9 +540,7 @@ class DataprocSparkSession(SparkSession):
             self.client.close()
             if self is DataprocSparkSession._default_session:
                 DataprocSparkSession._default_session = None
-            if self is getattr(
-                DataprocSparkSession._active_session, "session", None
-            ):
+            if self is getattr(DataprocSparkSession._active_session, "session", None):
                 DataprocSparkSession._active_session.session = None
 
 
@@ -570,7 +551,9 @@ def terminate_s8s_session(
 
     logger.debug(f"Terminating Dataproc Session: {active_s8s_session_id}")
     terminate_session_request = TerminateSessionRequest()
-    session_name = f"projects/{project_id}/locations/{region}/sessions/{active_s8s_session_id}"
+    session_name = (
+        f"projects/{project_id}/locations/{region}/sessions/{active_s8s_session_id}"
+    )
     terminate_session_request.name = session_name
     state = None
     try:
@@ -588,9 +571,7 @@ def terminate_s8s_session(
             state = session.state
             time.sleep(1)
     except NotFound:
-        logger.debug(
-            f"{active_s8s_session_id} Dataproc Session already deleted"
-        )
+        logger.debug(f"{active_s8s_session_id} Dataproc Session already deleted")
     # Client will get 'Aborted' error if session creation is still in progress and
     # 'FailedPrecondition' if another termination is still in progress.
     # Both are retryable, but we catch it and let TTL take care of cleanups.

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -432,6 +432,10 @@ class DataprocSparkSession(SparkSession):
                         f"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value:"
                         f" {default_datasource}. Supported value is 'bigquery'."
                     )
+            if "COLAB_NOTEBOOK_ID" in os.environ:
+                dataproc_config.labels["colab-notebook-id"] = (
+                    os.environ["COLAB_NOTEBOOK_ID"]
+                )
             return dataproc_config
 
         @staticmethod

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -406,13 +406,9 @@ class DataprocSparkSession(SparkSession):
                         os.getenv("DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS")
                     )
                 }
-            if "COLAB_NOTEBOOK_RUNTIME_ID" in os.environ:
-                dataproc_config.labels["colab-notebook-runtime-id"] = (
-                    os.environ["COLAB_NOTEBOOK_RUNTIME_ID"]
-                )
-            if "COLAB_NOTEBOOK_KERNEL_ID" in os.environ:
-                dataproc_config.labels["colab-notebook-kernel-id"] = os.environ[
-                    "COLAB_NOTEBOOK_KERNEL_ID"
+            if "COLAB_NOTEBOOK_ID" in os.environ:
+                dataproc_config.labels["colab-notebook-id"] = os.environ[
+                    "COLAB_NOTEBOOK_ID"
                 ]
             default_datasource = os.getenv(
                 "DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE"
@@ -438,10 +434,6 @@ class DataprocSparkSession(SparkSession):
                         f"DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE is set to an invalid value:"
                         f" {default_datasource}. Supported value is 'bigquery'."
                     )
-            if "COLAB_NOTEBOOK_ID" in os.environ:
-                dataproc_config.labels["colab-notebook-id"] = os.environ[
-                    "COLAB_NOTEBOOK_ID"
-                ]
             return dataproc_config
 
         @staticmethod

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -38,9 +38,7 @@ from unittest import mock
 class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
 
     def setUp(self):
-        self._default_runtime_version = (
-            DataprocSparkSession._DEFAULT_RUNTIME_VERSION
-        )
+        self._default_runtime_version = DataprocSparkSession._DEFAULT_RUNTIME_VERSION
         self.original_environment = dict(os.environ)
         os.environ.clear()
         os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
@@ -66,9 +64,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_create_spark_session_with_default_notebook_behavior(
         self,
         mock_is_s8s_session_active,
@@ -84,9 +80,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         )
 
         mock_dataproc_session_id.return_value = "sc-20240702-103952-abcdef"
-        mock_client_config.return_value = ConfigResult.fromProto(
-            ConfigResponse()
-        )
+        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
         cred = mock.MagicMock()
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
@@ -102,16 +96,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         )
 
         create_session_request = CreateSessionRequest()
-        create_session_request.parent = (
-            "projects/test-project/locations/test-region"
-        )
+        create_session_request.parent = "projects/test-project/locations/test-region"
         create_session_request.session.name = "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = (
-            SparkConnectConfig()
-        )
+        create_session_request.session.spark_connect_session = SparkConnectConfig()
         create_session_request.session_id = "sc-20240702-103952-abcdef"
 
         try:
@@ -191,9 +181,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_create_session_with_user_provided_dataproc_config(
         self,
         mock_is_s8s_session_active,
@@ -207,9 +195,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         mock_session_controller_client_instance = (
             mock_session_controller_client.return_value
         )
-        mock_client_config.return_value = ConfigResult.fromProto(
-            ConfigResponse()
-        )
+        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
         mock_dataproc_session_id.return_value = "sc-20240702-103952-abcdef"
         cred = mock.MagicMock()
         cred.token = "token"
@@ -232,9 +218,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.environment_config.execution_config.ttl = {
             "seconds": 10
         }
-        create_session_request.parent = (
-            "projects/test-project/locations/test-region"
-        )
+        create_session_request.parent = "projects/test-project/locations/test-region"
         create_session_request.session.name = "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
         create_session_request.session.runtime_config.properties = {
             "spark.executor.cores": "16"
@@ -242,9 +226,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = (
-            SparkConnectConfig()
-        )
+        create_session_request.session.spark_connect_session = SparkConnectConfig()
         create_session_request.session_id = "sc-20240702-103952-abcdef"
 
         try:
@@ -252,12 +234,8 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             dataproc_config.environment_config.execution_config.subnetwork_uri = (
                 "user_passed_subnetwork_uri"
             )
-            dataproc_config.environment_config.execution_config.ttl = {
-                "seconds": 10
-            }
-            dataproc_config.runtime_config.properties = {
-                "spark.executor.cores": "8"
-            }
+            dataproc_config.environment_config.execution_config.ttl = {"seconds": 10}
+            dataproc_config.runtime_config.properties = {"spark.executor.cores": "8"}
             session = (
                 DataprocSparkSession.builder.config("spark.executor.cores", "6")
                 .dataprocSessionConfig(dataproc_config)
@@ -288,9 +266,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_create_session_with_env_vars_config(
         self,
         mock_is_s8s_session_active,
@@ -347,16 +323,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             "seconds": 89
         }
         create_session_request.session.labels["colab-notebook-id"] = "test-notebook-id"
-        create_session_request.parent = (
-            "projects/test-project/locations/test-region"
-        )
+        create_session_request.parent = "projects/test-project/locations/test-region"
         create_session_request.session.name = "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = (
-            SparkConnectConfig()
-        )
+        create_session_request.session.spark_connect_session = SparkConnectConfig()
         create_session_request.session_id = "sc-20240702-103952-abcdef"
 
         try:
@@ -386,9 +358,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_create_session_with_session_template(
         self,
         mock_is_s8s_session_active,
@@ -403,9 +373,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             mock_session_controller_client.return_value
         )
         mock_dataproc_session_id.return_value = "sc-20240702-103952-abcdef"
-        mock_client_config.return_value = ConfigResult.fromProto(
-            ConfigResponse()
-        )
+        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
         cred = mock.MagicMock()
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
@@ -421,18 +389,16 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         )
 
         create_session_request = CreateSessionRequest()
-        create_session_request.parent = (
-            "projects/test-project/locations/test-region"
-        )
+        create_session_request.parent = "projects/test-project/locations/test-region"
         create_session_request.session.name = "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = (
-            SparkConnectConfig()
-        )
+        create_session_request.session.spark_connect_session = SparkConnectConfig()
         create_session_request.session_id = "sc-20240702-103952-abcdef"
-        create_session_request.session.session_template = "projects/test-project/locations/test-region/sessionTemplates/test_template"
+        create_session_request.session.session_template = (
+            "projects/test-project/locations/test-region/sessionTemplates/test_template"
+        )
 
         try:
             dataproc_config = Session()
@@ -465,9 +431,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_create_session_with_user_provided_dataproc_config_and_session_template(
         self,
         mock_is_s8s_session_active,
@@ -482,9 +446,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             mock_session_controller_client.return_value
         )
         mock_dataproc_session_id.return_value = "sc-20240702-103952-abcdef"
-        mock_client_config.return_value = ConfigResult.fromProto(
-            ConfigResponse()
-        )
+        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
         cred = mock.MagicMock()
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
@@ -500,9 +462,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         )
 
         create_session_request = CreateSessionRequest()
-        create_session_request.parent = (
-            "projects/test-project/locations/test-region"
-        )
+        create_session_request.parent = "projects/test-project/locations/test-region"
         create_session_request.session.environment_config.execution_config.ttl = {
             "seconds": 10
         }
@@ -510,17 +470,15 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = (
-            SparkConnectConfig()
+        create_session_request.session.spark_connect_session = SparkConnectConfig()
+        create_session_request.session.session_template = (
+            "projects/test-project/locations/test-region/sessionTemplates/test_template"
         )
-        create_session_request.session.session_template = "projects/test-project/locations/test-region/sessionTemplates/test_template"
         create_session_request.session_id = "sc-20240702-103952-abcdef"
 
         try:
             dataproc_config = Session()
-            dataproc_config.environment_config.execution_config.ttl = {
-                "seconds": 10
-            }
+            dataproc_config.environment_config.execution_config.ttl = {"seconds": 10}
             dataproc_config.session_template = "projects/test-project/locations/test-region/sessionTemplates/test_template"
             session = DataprocSparkSession.builder.dataprocSessionConfig(
                 dataproc_config
@@ -560,9 +518,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             mock_session_controller_client.return_value
         )
         mock_operation = mock.Mock()
-        mock_operation.result.side_effect = Exception(
-            "Testing create session failure"
-        )
+        mock_operation.result.side_effect = Exception("Testing create session failure")
         mock_session_controller_client_instance.create_session.return_value = (
             mock_operation
         )
@@ -570,12 +526,8 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
         with self.assertRaises(RuntimeError) as e:
-            DataprocSparkSession.builder.dataprocSessionConfig(
-                Session()
-            ).getOrCreate()
-        self.assertEqual(
-            "Error while creating Dataproc Session", e.exception.args[0]
-        )
+            DataprocSparkSession.builder.dataprocSessionConfig(Session()).getOrCreate()
+        self.assertEqual("Error while creating Dataproc Session", e.exception.args[0])
 
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
@@ -598,9 +550,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
         with self.assertRaises(DataprocSparkConnectException) as e:
-            DataprocSparkSession.builder.dataprocSessionConfig(
-                Session()
-            ).getOrCreate()
+            DataprocSparkSession.builder.dataprocSessionConfig(Session()).getOrCreate()
             self.assertEqual(
                 e.exception.error_message,
                 "Error while creating Dataproc Session: "
@@ -612,9 +562,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_spark_session_with_inactive_s8s_session(
         self,
         mock_is_s8s_session_active,
@@ -657,9 +605,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_stop_spark_session_with_terminated_s8s_session(
         self,
         mock_is_s8s_session_active,
@@ -686,14 +632,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             cred = mock.MagicMock()
             cred.token = "token"
             mock_credentials.return_value = (cred, "")
-            mock_client_config.return_value = ConfigResult.fromProto(
-                ConfigResponse()
-            )
+            mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
             session = DataprocSparkSession.builder.getOrCreate()
 
         finally:
-            mock_session_controller_client_instance.terminate_session.side_effect = FailedPrecondition(
-                "Already terminated"
+            mock_session_controller_client_instance.terminate_session.side_effect = (
+                FailedPrecondition("Already terminated")
             )
             if session is not None:
                 session.stop()
@@ -702,9 +646,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_stop_spark_session_with_creating_s8s_session(
         self,
         mock_is_s8s_session_active,
@@ -731,14 +673,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             cred = mock.MagicMock()
             cred.token = "token"
             mock_credentials.return_value = (cred, "")
-            mock_client_config.return_value = ConfigResult.fromProto(
-                ConfigResponse()
-            )
+            mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
             session = DataprocSparkSession.builder.getOrCreate()
 
         finally:
-            mock_session_controller_client_instance.terminate_session.side_effect = Aborted(
-                "still being created"
+            mock_session_controller_client_instance.terminate_session.side_effect = (
+                Aborted("still being created")
             )
             if session is not None:
                 session.stop()
@@ -747,9 +687,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_stop_spark_session_with_deleted_s8s_session(
         self,
         mock_is_s8s_session_active,
@@ -776,14 +714,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             cred = mock.MagicMock()
             cred.token = "token"
             mock_credentials.return_value = (cred, "")
-            mock_client_config.return_value = ConfigResult.fromProto(
-                ConfigResponse()
-            )
+            mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
             session = DataprocSparkSession.builder.getOrCreate()
 
         finally:
-            mock_session_controller_client_instance.terminate_session.side_effect = NotFound(
-                "Already deleted"
+            mock_session_controller_client_instance.terminate_session.side_effect = (
+                NotFound("Already deleted")
             )
             if session is not None:
                 session.stop()
@@ -795,9 +731,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
     def test_stop_spark_session_wait_for_terminating_state(
         self,
         mock_is_s8s_session_active,
@@ -826,9 +760,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             cred = mock.MagicMock()
             cred.token = "token"
             mock_credentials.return_value = (cred, "")
-            mock_client_config.return_value = ConfigResult.fromProto(
-                ConfigResponse()
-            )
+            mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
             session = DataprocSparkSession.builder.getOrCreate()
 
         finally:
@@ -857,12 +789,8 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
-    )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.session.logger"
-    )  # Mock the logger
+    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch("google.cloud.dataproc_spark_connect.session.logger")  # Mock the logger
     def test_create_session_with_default_datasource_env_var(
         self,
         mock_logger,  # Add mock logger parameter
@@ -880,9 +808,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         mock_dataproc_session_id.return_value = (
             "c002e4ef-fe5e-41a8-a157-160aa73e4f7f"  # Use a valid UUID
         )
-        mock_client_config.return_value = ConfigResult.fromProto(
-            ConfigResponse()
-        )
+        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
         cred = mock.MagicMock()
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
@@ -911,11 +837,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             session = DataprocSparkSession.builder.getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[
-                0
-            ][
-                0
-            ]
+            create_session_request = (
+                mock_session_controller_client_instance.create_session.call_args[0][0]
+            )
             self.assertNotIn(
                 "spark.datasource.bigquery.writeMethod",
                 create_session_request.session.runtime_config.properties,
@@ -934,11 +858,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             session = DataprocSparkSession.builder.getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[
-                0
-            ][
-                0
-            ]
+            create_session_request = (
+                mock_session_controller_client_instance.create_session.call_args[0][0]
+            )
             # With runtime version 2.3, the BigQuery properties should be set
             self.assertEqual(
                 create_session_request.session.runtime_config.properties.get(
@@ -990,11 +912,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             session = DataprocSparkSession.builder.dataprocSessionConfig(
                 dataproc_config
             ).getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[
-                0
-            ][
-                0
-            ]
+            create_session_request = (
+                mock_session_controller_client_instance.create_session.call_args[0][0]
+            )
             # With runtime version 2.2, the BigQuery properties should NOT be set
             self.assertNotIn(
                 "spark.datasource.bigquery.writeMethod",
@@ -1034,11 +954,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             session = DataprocSparkSession.builder.dataprocSessionConfig(
                 dataproc_config
             ).getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[
-                0
-            ][
-                0
-            ]
+            create_session_request = (
+                mock_session_controller_client_instance.create_session.call_args[0][0]
+            )
             # With runtime version > 2.3, the BigQuery properties should be set
             self.assertEqual(
                 create_session_request.session.runtime_config.properties.get(
@@ -1084,11 +1002,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             session = DataprocSparkSession.builder.getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[
-                0
-            ][
-                0
-            ]
+            create_session_request = (
+                mock_session_controller_client_instance.create_session.call_args[0][0]
+            )
             self.assertNotIn(
                 "spark.datasource.bigquery.writeMethod",
                 create_session_request.session.runtime_config.properties,
@@ -1117,11 +1033,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             session = DataprocSparkSession.builder.dataprocSessionConfig(
                 dataproc_config
             ).getOrCreate()
-            create_session_request = mock_session_controller_client_instance.create_session.call_args[
-                0
-            ][
-                0
-            ]
+            create_session_request = (
+                mock_session_controller_client_instance.create_session.call_args[0][0]
+            )
             # With runtime version 2.3, the BigQuery default properties should be set,
             # but pre-existing properties should override defaults.
             self.assertEqual(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -326,6 +326,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
                 "DATAPROC_SPARK_CONNECT_SUBNET": "test-subnet-from-env",
                 "DATAPROC_SPARK_CONNECT_TTL_SECONDS": "12",
                 "DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS": "89",
+                "COLAB_NOTEBOOK_ID": "test-notebook-id",
             },
         ).start()
 
@@ -345,6 +346,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.environment_config.execution_config.idle_ttl = {
             "seconds": 89
         }
+        create_session_request.session.labels["colab-notebook-id"] = "test-notebook-id"
         create_session_request.parent = (
             "projects/test-project/locations/test-region"
         )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -38,7 +38,9 @@ from unittest import mock
 class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
 
     def setUp(self):
-        self._default_runtime_version = DataprocSparkSession._DEFAULT_RUNTIME_VERSION
+        self._default_runtime_version = (
+            DataprocSparkSession._DEFAULT_RUNTIME_VERSION
+        )
         self.original_environment = dict(os.environ)
         os.environ.clear()
         os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
@@ -64,7 +66,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_create_spark_session_with_default_notebook_behavior(
         self,
         mock_is_s8s_session_active,
@@ -80,7 +84,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         )
 
         mock_dataproc_session_id.return_value = "sc-20240702-103952-abcdef"
-        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
+        mock_client_config.return_value = ConfigResult.fromProto(
+            ConfigResponse()
+        )
         cred = mock.MagicMock()
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
@@ -96,12 +102,16 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         )
 
         create_session_request = CreateSessionRequest()
-        create_session_request.parent = "projects/test-project/locations/test-region"
+        create_session_request.parent = (
+            "projects/test-project/locations/test-region"
+        )
         create_session_request.session.name = "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = SparkConnectConfig()
+        create_session_request.session.spark_connect_session = (
+            SparkConnectConfig()
+        )
         create_session_request.session_id = "sc-20240702-103952-abcdef"
 
         try:
@@ -181,7 +191,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_create_session_with_user_provided_dataproc_config(
         self,
         mock_is_s8s_session_active,
@@ -195,7 +207,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         mock_session_controller_client_instance = (
             mock_session_controller_client.return_value
         )
-        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
+        mock_client_config.return_value = ConfigResult.fromProto(
+            ConfigResponse()
+        )
         mock_dataproc_session_id.return_value = "sc-20240702-103952-abcdef"
         cred = mock.MagicMock()
         cred.token = "token"
@@ -218,7 +232,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.environment_config.execution_config.ttl = {
             "seconds": 10
         }
-        create_session_request.parent = "projects/test-project/locations/test-region"
+        create_session_request.parent = (
+            "projects/test-project/locations/test-region"
+        )
         create_session_request.session.name = "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
         create_session_request.session.runtime_config.properties = {
             "spark.executor.cores": "16"
@@ -226,7 +242,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = SparkConnectConfig()
+        create_session_request.session.spark_connect_session = (
+            SparkConnectConfig()
+        )
         create_session_request.session_id = "sc-20240702-103952-abcdef"
 
         try:
@@ -234,8 +252,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             dataproc_config.environment_config.execution_config.subnetwork_uri = (
                 "user_passed_subnetwork_uri"
             )
-            dataproc_config.environment_config.execution_config.ttl = {"seconds": 10}
-            dataproc_config.runtime_config.properties = {"spark.executor.cores": "8"}
+            dataproc_config.environment_config.execution_config.ttl = {
+                "seconds": 10
+            }
+            dataproc_config.runtime_config.properties = {
+                "spark.executor.cores": "8"
+            }
             session = (
                 DataprocSparkSession.builder.config("spark.executor.cores", "6")
                 .dataprocSessionConfig(dataproc_config)
@@ -266,7 +288,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_create_session_with_env_vars_config(
         self,
         mock_is_s8s_session_active,
@@ -322,13 +346,19 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.environment_config.execution_config.idle_ttl = {
             "seconds": 89
         }
-        create_session_request.session.labels["colab-notebook-id"] = "test-notebook-id"
-        create_session_request.parent = "projects/test-project/locations/test-region"
+        create_session_request.session.labels["colab-notebook-id"] = (
+            "test-notebook-id"
+        )
+        create_session_request.parent = (
+            "projects/test-project/locations/test-region"
+        )
         create_session_request.session.name = "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = SparkConnectConfig()
+        create_session_request.session.spark_connect_session = (
+            SparkConnectConfig()
+        )
         create_session_request.session_id = "sc-20240702-103952-abcdef"
 
         try:
@@ -358,7 +388,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_create_session_with_session_template(
         self,
         mock_is_s8s_session_active,
@@ -373,7 +405,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             mock_session_controller_client.return_value
         )
         mock_dataproc_session_id.return_value = "sc-20240702-103952-abcdef"
-        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
+        mock_client_config.return_value = ConfigResult.fromProto(
+            ConfigResponse()
+        )
         cred = mock.MagicMock()
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
@@ -389,16 +423,18 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         )
 
         create_session_request = CreateSessionRequest()
-        create_session_request.parent = "projects/test-project/locations/test-region"
+        create_session_request.parent = (
+            "projects/test-project/locations/test-region"
+        )
         create_session_request.session.name = "projects/test-project/locations/test-region/sessions/sc-20240702-103952-abcdef"
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = SparkConnectConfig()
-        create_session_request.session_id = "sc-20240702-103952-abcdef"
-        create_session_request.session.session_template = (
-            "projects/test-project/locations/test-region/sessionTemplates/test_template"
+        create_session_request.session.spark_connect_session = (
+            SparkConnectConfig()
         )
+        create_session_request.session_id = "sc-20240702-103952-abcdef"
+        create_session_request.session.session_template = "projects/test-project/locations/test-region/sessionTemplates/test_template"
 
         try:
             dataproc_config = Session()
@@ -431,7 +467,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_create_session_with_user_provided_dataproc_config_and_session_template(
         self,
         mock_is_s8s_session_active,
@@ -446,7 +484,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             mock_session_controller_client.return_value
         )
         mock_dataproc_session_id.return_value = "sc-20240702-103952-abcdef"
-        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
+        mock_client_config.return_value = ConfigResult.fromProto(
+            ConfigResponse()
+        )
         cred = mock.MagicMock()
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
@@ -462,7 +502,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         )
 
         create_session_request = CreateSessionRequest()
-        create_session_request.parent = "projects/test-project/locations/test-region"
+        create_session_request.parent = (
+            "projects/test-project/locations/test-region"
+        )
         create_session_request.session.environment_config.execution_config.ttl = {
             "seconds": 10
         }
@@ -470,15 +512,17 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.runtime_config.version = (
             self._default_runtime_version
         )
-        create_session_request.session.spark_connect_session = SparkConnectConfig()
-        create_session_request.session.session_template = (
-            "projects/test-project/locations/test-region/sessionTemplates/test_template"
+        create_session_request.session.spark_connect_session = (
+            SparkConnectConfig()
         )
+        create_session_request.session.session_template = "projects/test-project/locations/test-region/sessionTemplates/test_template"
         create_session_request.session_id = "sc-20240702-103952-abcdef"
 
         try:
             dataproc_config = Session()
-            dataproc_config.environment_config.execution_config.ttl = {"seconds": 10}
+            dataproc_config.environment_config.execution_config.ttl = {
+                "seconds": 10
+            }
             dataproc_config.session_template = "projects/test-project/locations/test-region/sessionTemplates/test_template"
             session = DataprocSparkSession.builder.dataprocSessionConfig(
                 dataproc_config
@@ -518,7 +562,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             mock_session_controller_client.return_value
         )
         mock_operation = mock.Mock()
-        mock_operation.result.side_effect = Exception("Testing create session failure")
+        mock_operation.result.side_effect = Exception(
+            "Testing create session failure"
+        )
         mock_session_controller_client_instance.create_session.return_value = (
             mock_operation
         )
@@ -526,8 +572,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
         with self.assertRaises(RuntimeError) as e:
-            DataprocSparkSession.builder.dataprocSessionConfig(Session()).getOrCreate()
-        self.assertEqual("Error while creating Dataproc Session", e.exception.args[0])
+            DataprocSparkSession.builder.dataprocSessionConfig(
+                Session()
+            ).getOrCreate()
+        self.assertEqual(
+            "Error while creating Dataproc Session", e.exception.args[0]
+        )
 
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
@@ -550,7 +600,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
         with self.assertRaises(DataprocSparkConnectException) as e:
-            DataprocSparkSession.builder.dataprocSessionConfig(Session()).getOrCreate()
+            DataprocSparkSession.builder.dataprocSessionConfig(
+                Session()
+            ).getOrCreate()
             self.assertEqual(
                 e.exception.error_message,
                 "Error while creating Dataproc Session: "
@@ -562,7 +614,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_spark_session_with_inactive_s8s_session(
         self,
         mock_is_s8s_session_active,
@@ -605,7 +659,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_stop_spark_session_with_terminated_s8s_session(
         self,
         mock_is_s8s_session_active,
@@ -632,12 +688,14 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             cred = mock.MagicMock()
             cred.token = "token"
             mock_credentials.return_value = (cred, "")
-            mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
+            mock_client_config.return_value = ConfigResult.fromProto(
+                ConfigResponse()
+            )
             session = DataprocSparkSession.builder.getOrCreate()
 
         finally:
-            mock_session_controller_client_instance.terminate_session.side_effect = (
-                FailedPrecondition("Already terminated")
+            mock_session_controller_client_instance.terminate_session.side_effect = FailedPrecondition(
+                "Already terminated"
             )
             if session is not None:
                 session.stop()
@@ -646,7 +704,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_stop_spark_session_with_creating_s8s_session(
         self,
         mock_is_s8s_session_active,
@@ -673,12 +733,14 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             cred = mock.MagicMock()
             cred.token = "token"
             mock_credentials.return_value = (cred, "")
-            mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
+            mock_client_config.return_value = ConfigResult.fromProto(
+                ConfigResponse()
+            )
             session = DataprocSparkSession.builder.getOrCreate()
 
         finally:
-            mock_session_controller_client_instance.terminate_session.side_effect = (
-                Aborted("still being created")
+            mock_session_controller_client_instance.terminate_session.side_effect = Aborted(
+                "still being created"
             )
             if session is not None:
                 session.stop()
@@ -687,7 +749,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_stop_spark_session_with_deleted_s8s_session(
         self,
         mock_is_s8s_session_active,
@@ -714,12 +778,14 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             cred = mock.MagicMock()
             cred.token = "token"
             mock_credentials.return_value = (cred, "")
-            mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
+            mock_client_config.return_value = ConfigResult.fromProto(
+                ConfigResponse()
+            )
             session = DataprocSparkSession.builder.getOrCreate()
 
         finally:
-            mock_session_controller_client_instance.terminate_session.side_effect = (
-                NotFound("Already deleted")
+            mock_session_controller_client_instance.terminate_session.side_effect = NotFound(
+                "Already deleted"
             )
             if session is not None:
                 session.stop()
@@ -731,7 +797,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
     def test_stop_spark_session_wait_for_terminating_state(
         self,
         mock_is_s8s_session_active,
@@ -760,7 +828,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             cred = mock.MagicMock()
             cred.token = "token"
             mock_credentials.return_value = (cred, "")
-            mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
+            mock_client_config.return_value = ConfigResult.fromProto(
+                ConfigResponse()
+            )
             session = DataprocSparkSession.builder.getOrCreate()
 
         finally:
@@ -789,8 +859,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
     @mock.patch(
         "google.cloud.dataproc_spark_connect.DataprocSparkSession.Builder.generate_dataproc_session_id"
     )
-    @mock.patch("google.cloud.dataproc_spark_connect.session.is_s8s_session_active")
-    @mock.patch("google.cloud.dataproc_spark_connect.session.logger")  # Mock the logger
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.is_s8s_session_active"
+    )
+    @mock.patch(
+        "google.cloud.dataproc_spark_connect.session.logger"
+    )  # Mock the logger
     def test_create_session_with_default_datasource_env_var(
         self,
         mock_logger,  # Add mock logger parameter
@@ -808,7 +882,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         mock_dataproc_session_id.return_value = (
             "c002e4ef-fe5e-41a8-a157-160aa73e4f7f"  # Use a valid UUID
         )
-        mock_client_config.return_value = ConfigResult.fromProto(ConfigResponse())
+        mock_client_config.return_value = ConfigResult.fromProto(
+            ConfigResponse()
+        )
         cred = mock.MagicMock()
         cred.token = "token"
         mock_credentials.return_value = (cred, "")
@@ -837,9 +913,11 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             session = DataprocSparkSession.builder.getOrCreate()
-            create_session_request = (
-                mock_session_controller_client_instance.create_session.call_args[0][0]
-            )
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             self.assertNotIn(
                 "spark.datasource.bigquery.writeMethod",
                 create_session_request.session.runtime_config.properties,
@@ -858,9 +936,11 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             session = DataprocSparkSession.builder.getOrCreate()
-            create_session_request = (
-                mock_session_controller_client_instance.create_session.call_args[0][0]
-            )
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             # With runtime version 2.3, the BigQuery properties should be set
             self.assertEqual(
                 create_session_request.session.runtime_config.properties.get(
@@ -912,9 +992,11 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             session = DataprocSparkSession.builder.dataprocSessionConfig(
                 dataproc_config
             ).getOrCreate()
-            create_session_request = (
-                mock_session_controller_client_instance.create_session.call_args[0][0]
-            )
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             # With runtime version 2.2, the BigQuery properties should NOT be set
             self.assertNotIn(
                 "spark.datasource.bigquery.writeMethod",
@@ -954,9 +1036,11 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             session = DataprocSparkSession.builder.dataprocSessionConfig(
                 dataproc_config
             ).getOrCreate()
-            create_session_request = (
-                mock_session_controller_client_instance.create_session.call_args[0][0]
-            )
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             # With runtime version > 2.3, the BigQuery properties should be set
             self.assertEqual(
                 create_session_request.session.runtime_config.properties.get(
@@ -1002,9 +1086,11 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
             os.environ["GOOGLE_CLOUD_REGION"] = "test-region"
             session = DataprocSparkSession.builder.getOrCreate()
-            create_session_request = (
-                mock_session_controller_client_instance.create_session.call_args[0][0]
-            )
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             self.assertNotIn(
                 "spark.datasource.bigquery.writeMethod",
                 create_session_request.session.runtime_config.properties,
@@ -1033,9 +1119,11 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             session = DataprocSparkSession.builder.dataprocSessionConfig(
                 dataproc_config
             ).getOrCreate()
-            create_session_request = (
-                mock_session_controller_client_instance.create_session.call_args[0][0]
-            )
+            create_session_request = mock_session_controller_client_instance.create_session.call_args[
+                0
+            ][
+                0
+            ]
             # With runtime version 2.3, the BigQuery default properties should be set,
             # but pre-existing properties should override defaults.
             self.assertEqual(


### PR DESCRIPTION
This change adds the `colab-notebook-id` label to the Dataproc Spark Connect session if the `COLAB_NOTEBOOK_ID` environment variable is set. This allows users to track sessions created from Colab notebooks.