### PR TITLE
Refactor: Remove redundant option application in DataprocSparkSession. The redundant config passing to spark session caused unwanted warning.

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -83,16 +83,6 @@ class DataprocSparkSession(SparkSession):
 
     class Builder(SparkSession.Builder):
 
-        _session_static_configs = [
-            "spark.executor.cores",
-            "spark.executor.memoryOverhead",
-            "spark.executor.memory",
-            "spark.driver.memory",
-            "spark.driver.cores",
-            "spark.eventLog.dir",
-            "spark.history.fs.logDirectory",
-        ]
-
         def __init__(self):
             self._options: Dict[str, Any] = {}
             self._channel_builder: Optional[DataprocChannelBuilder] = None

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -106,15 +106,6 @@ class DataprocSparkSession(SparkSession):
                 )
             )
 
-        def __apply_options(self, session: "SparkSession") -> None:
-            with self._lock:
-                self._options = {
-                    key: value
-                    for key, value in self._options.items()
-                    if key not in self._session_static_configs
-                }
-                self._apply_options(session)
-
         def projectId(self, project_id):
             self._project_id = project_id
             return self
@@ -172,7 +163,6 @@ class DataprocSparkSession(SparkSession):
             session = DataprocSparkSession(connection=self._channel_builder)
 
             DataprocSparkSession._set_default_and_active_session(session)
-            self.__apply_options(session)
             return session
 
         def __create(self) -> "DataprocSparkSession":
@@ -350,8 +340,6 @@ class DataprocSparkSession(SparkSession):
                 session = self._get_exiting_active_session()
                 if session is None:
                     session = self.__create()
-                if session:
-                    self.__apply_options(session)
                 return session
 
         def _get_dataproc_config(self):


### PR DESCRIPTION
The `__apply_options` method was being called multiple times during session creation and retrieval, leading to potential inconsistencies and unnecessary operations. This commit removes the redundant calls to ensure options are applied only once during session initialization, streamlining the configuration process.

All integration tests passed. All unit tests passed except the timeout tests. No test updates needed. 