### PR TITLE
Fix: Store Colab notebook ID in runtime properties

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -385,9 +385,9 @@ class DataprocSparkSession(SparkSession):
                     )
                 }
             if "COLAB_NOTEBOOK_ID" in os.environ:
-                dataproc_config.labels["colab-notebook-id"] = os.environ[
-                    "COLAB_NOTEBOOK_ID"
-                ]
+                dataproc_config.runtime_config.properties[
+                    "colab_notebook_id"
+                ] = os.environ["COLAB_NOTEBOOK_ID"]
             default_datasource = os.getenv(
                 "DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE"
             )

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -120,6 +120,11 @@ def test_create_spark_session_with_default_notebook_behavior(
     get_session_request.name = session_name
     session = session_controller_client.get_session(get_session_request)
     assert session.state == Session.State.ACTIVE
+    if "COLAB_NOTEBOOK_ID" in os.environ:
+        assert (
+            session.runtime_config.properties["colab_notebook_id"]
+            == os.environ["COLAB_NOTEBOOK_ID"]
+        )
 
     df = connect_session.createDataFrame([(1, "Sarah"), (2, "Maria")]).toDF(
         "id", "name"
@@ -144,23 +149,6 @@ def test_create_spark_session_with_default_notebook_behavior(
         Session.State.TERMINATED,
     ]
     assert DataprocSparkSession._active_s8s_session_uuid is None
-
-
-def test_create_spark_session_with_colab_notebook_id(
-    connect_session, session_name, session_controller_client
-):
-    os.environ["COLAB_NOTEBOOK_ID"] = (
-        "/embedded/projects/company.com%3Aprojectid/locations/us-central1/repositories/d2943429-2624-4e20-9c15-d9b649471342"
-    )
-    get_session_request = GetSessionRequest()
-    get_session_request.name = session_name
-    session = session_controller_client.get_session(get_session_request)
-    assert session.state == Session.State.ACTIVE
-    assert (
-        session.runtime_config.properties["colab_notebook_id"]
-        == "/embedded/projects/company.com%3Aprojectid/locations/us-central1/repositories/d2943429-2624-4e20-9c15-d9b649471342"
-    )
-    connect_session.stop()
 
 
 def test_reuse_s8s_spark_session(

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -146,6 +146,23 @@ def test_create_spark_session_with_default_notebook_behavior(
     assert DataprocSparkSession._active_s8s_session_uuid is None
 
 
+def test_create_spark_session_with_colab_notebook_id(
+    connect_session, session_name, session_controller_client
+):
+    os.environ["COLAB_NOTEBOOK_ID"] = (
+        "/embedded/projects/company.com%3Aprojectid/locations/us-central1/repositories/d2943429-2624-4e20-9c15-d9b649471342"
+    )
+    get_session_request = GetSessionRequest()
+    get_session_request.name = session_name
+    session = session_controller_client.get_session(get_session_request)
+    assert session.state == Session.State.ACTIVE
+    assert (
+        session.runtime_config.properties["colab_notebook_id"]
+        == "/embedded/projects/company.com%3Aprojectid/locations/us-central1/repositories/d2943429-2624-4e20-9c15-d9b649471342"
+    )
+    connect_session.stop()
+
+
 def test_reuse_s8s_spark_session(
     connect_session, session_name, session_controller_client
 ):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -326,7 +326,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
                 "DATAPROC_SPARK_CONNECT_SUBNET": "test-subnet-from-env",
                 "DATAPROC_SPARK_CONNECT_TTL_SECONDS": "12",
                 "DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS": "89",
-                "COLAB_NOTEBOOK_ID": "test-notebook-id",
+                "COLAB_NOTEBOOK_ID": "/embedded/projects/company.com%3Aprojectid/locations/us-central1/repositories/d2943429-2624-4e20-9c15-d9b649471342",
             },
         ).start()
 
@@ -346,9 +346,9 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
         create_session_request.session.environment_config.execution_config.idle_ttl = {
             "seconds": 89
         }
-        create_session_request.session.labels["colab-notebook-id"] = (
-            "test-notebook-id"
-        )
+        create_session_request.session.runtime_config.properties[
+            "colab_notebook_id"
+        ] = "/embedded/projects/company.com%3Aprojectid/locations/us-central1/repositories/d2943429-2624-4e20-9c15-d9b649471342"
         create_session_request.parent = (
             "projects/test-project/locations/test-region"
         )


### PR DESCRIPTION
This commit moves the storage of the Colab notebook ID from session labels to runtime properties. This change aligns with the expected configuration and ensures the ID is correctly passed to the Dataproc Spark Connect session. Additionally, integration and unit tests were updated to reflect this change.