### PR TITLE
Fix: Extract Colab notebook ID from full path

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -407,9 +407,11 @@ class DataprocSparkSession(SparkSession):
                     )
                 }
             if "COLAB_NOTEBOOK_ID" in os.environ:
-                dataproc_config.labels["colab-notebook-id"] = os.environ[
-                    "COLAB_NOTEBOOK_ID"
-                ]
+                colab_notebook_id_full = os.environ["COLAB_NOTEBOOK_ID"]
+                # Extract the last part of the path, which is the ID
+                dataproc_config.labels["colab-notebook-id"] = os.path.basename(
+                    colab_notebook_id_full
+                )
             default_datasource = os.getenv(
                 "DATAPROC_SPARK_CONNECT_DEFAULT_DATASOURCE"
             )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -326,7 +326,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
                 "DATAPROC_SPARK_CONNECT_SUBNET": "test-subnet-from-env",
                 "DATAPROC_SPARK_CONNECT_TTL_SECONDS": "12",
                 "DATAPROC_SPARK_CONNECT_IDLE_TTL_SECONDS": "89",
-                "COLAB_NOTEBOOK_ID": "test-notebook-id",
+                "COLAB_NOTEBOOK_ID": "/embedded/projects/company.com%3Aproject1/locations/us-central1/repositories/test-notebook-id",
             },
         ).start()
 
@@ -347,7 +347,7 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             "seconds": 89
         }
         create_session_request.session.labels["colab-notebook-id"] = (
-            "test-notebook-id"
+            "test-notebook-id"  # Expecting the basename
         )
         create_session_request.parent = (
             "projects/test-project/locations/test-region"


### PR DESCRIPTION
The Dataproc Spark Connect session was using the full path of the Colab notebook ID, instead of just the ID itself, as a label. This change extracts the basename of the path to ensure only the ID is used. This is done to align with expected behavior and avoid issues with overly long label values. The unit test was also updated to reflect this change.