### PR TITLE
fix: Fix unit tests providing needed mock dependencies

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -454,6 +454,10 @@ class DataprocSparkSession(SparkSession):
             try:
                 session_url = f"https://console.cloud.google.com/dataproc/interactive/sessions/{session_id}/locations/{self._region}?project={self._project_id}"
                 from google.cloud.aiplatform.utils import _ipython_utils
+                from IPython.core.interactiveshell import InteractiveShell
+
+                if not InteractiveShell.initialized():
+                    return
 
                 _ipython_utils.display_link(
                     "View Session Details", f"{session_url}", "dashboard"

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -453,11 +453,12 @@ class DataprocSparkSession(SparkSession):
         def _display_view_session_details_button(self, session_id):
             try:
                 session_url = f"https://console.cloud.google.com/dataproc/interactive/sessions/{session_id}/locations/{self._region}?project={self._project_id}"
-                from google.cloud.aiplatform.utils import _ipython_utils
                 from IPython.core.interactiveshell import InteractiveShell
 
                 if not InteractiveShell.initialized():
                     return
+
+                from google.cloud.aiplatform.utils import _ipython_utils
 
                 _ipython_utils.display_link(
                     "View Session Details", f"{session_url}", "dashboard"

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1187,19 +1187,47 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             ),
         },
     )
-    def test_display_button_with_aiplatform_installed(self):
+    @mock.patch("IPython.core.interactiveshell.InteractiveShell.initialized")
+    def test_display_button_with_aiplatform_installed_ipython_interactive(
+        self, mock_initialized
+    ):
         mock_ipython_utils = mock.sys.modules[
             "google.cloud.aiplatform.utils"
         ]._ipython_utils
         test_session_url = "https://console.cloud.google.com/dataproc/interactive/sessions/test_session/locations/test-region?project=test-project"
 
         mock_display_link = mock_ipython_utils.display_link
+        mock_initialized.return_value = True
         DataprocSparkSession.builder._display_view_session_details_button(
             "test_session"
         )
         mock_display_link.assert_called_once_with(
             "View Session Details", test_session_url, "dashboard"
         )
+
+    @mock.patch.dict(
+        "sys.modules",
+        {
+            "google.cloud.aiplatform.utils": mock.MagicMock(
+                _ipython_utils=mock.MagicMock()
+            ),
+        },
+    )
+    @mock.patch("IPython.core.interactiveshell.InteractiveShell.initialized")
+    def test_display_button_with_aiplatform_installed_ipython_non_interactive(
+        self, mock_initialized
+    ):
+        mock_ipython_utils = mock.sys.modules[
+            "google.cloud.aiplatform.utils"
+        ]._ipython_utils
+        test_session_url = "https://console.cloud.google.com/dataproc/interactive/sessions/test_session/locations/test-region?project=test-project"
+
+        mock_display_link = mock_ipython_utils.display_link
+        mock_initialized.return_value = False
+        DataprocSparkSession.builder._display_view_session_details_button(
+            "test_session"
+        )
+        mock_display_link.assert_not_called()
 
     def test_is_valid_label_value(self):
         # Valid label values

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1170,8 +1170,12 @@ class DataprocRemoteSparkSessionBuilderTests(unittest.TestCase):
             mock_logger.warning.reset_mock()
 
     @mock.patch("sys.modules", {"google.cloud.aiplatform": None})
+    @mock.patch("IPython.core.interactiveshell.InteractiveShell.initialized")
     @mock.patch("google.cloud.dataproc_spark_connect.session.logger")
-    def test_display_button_with_aiplatform_not_installed(self, mock_logger):
+    def test_display_button_with_aiplatform_not_installed(
+        self, mock_logger, mock_initialized
+    ):
+        mock_initialized.return_value = True
         DataprocSparkSession.builder._display_view_session_details_button(
             "test_session"
         )


### PR DESCRIPTION
This is a follow-up fix for PR #106 