### PR TITLE
fix: Update per-operation Spark UI URL print logic to skip SELECT clause

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -22,6 +22,7 @@ import re
 import string
 import threading
 import time
+from types import MethodType
 from typing import Any, cast, ClassVar, Dict, Optional, Union
 import uuid
 import tqdm
@@ -541,19 +542,54 @@ class DataprocSparkSession(SparkSession):
 
         super().__init__(connection, user_id)
 
-        base_method = self.client._execute_plan_request_with_metadata
+        execute_plan_request_base_method = (
+            self.client._execute_plan_request_with_metadata
+        )
+        execute_base_method = self.client._execute
+        execute_and_fetch_as_iterator_base_method = (
+            self.client._execute_and_fetch_as_iterator
+        )
 
-        def wrapped_method(*args, **kwargs):
-            req = base_method(*args, **kwargs)
+        def execute_plan_request_wrapped_method(*args, **kwargs):
+            req = execute_plan_request_base_method(*args, **kwargs)
             if not req.operation_id:
                 req.operation_id = str(uuid.uuid4())
                 logger.debug(
                     f"No operation_id found. Setting operation_id: {req.operation_id}"
                 )
-            self._display_operation_link(req.operation_id)
             return req
 
-        self.client._execute_plan_request_with_metadata = wrapped_method
+        self.client._execute_plan_request_with_metadata = (
+            execute_plan_request_wrapped_method
+        )
+
+        def execute_wrapped_method(client_self, req, *args, **kwargs):
+            if not (self._sql_lazy_transformation(req)):
+                self._display_operation_link(req.operation_id)
+            execute_base_method(req, *args, **kwargs)
+
+        self.client._execute = MethodType(execute_wrapped_method, self.client)
+
+        def execute_and_fetch_as_iterator_wrapped_method(
+            client_self, req, *args, **kwargs
+        ):
+            if not (self._sql_lazy_transformation(req)):
+                self._display_operation_link(req.operation_id)
+            return execute_and_fetch_as_iterator_base_method(
+                req, *args, **kwargs
+            )
+
+        self.client._execute_and_fetch_as_iterator = MethodType(
+            execute_and_fetch_as_iterator_wrapped_method, self.client
+        )
+
+    @staticmethod
+    def _sql_lazy_transformation(req):
+        # Select SQL command
+        if req.plan and req.plan.command and req.plan.command.sql_command:
+            return "select" in req.plan.command.sql_command.sql.lower()
+
+        return False
 
     def _repr_html_(self) -> str:
         if not self._active_s8s_session_id:

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -564,7 +564,7 @@ class DataprocSparkSession(SparkSession):
         )
 
         def execute_wrapped_method(client_self, req, *args, **kwargs):
-            if not (self._sql_lazy_transformation(req)):
+            if not self._sql_lazy_transformation(req):
                 self._display_operation_link(req.operation_id)
             execute_base_method(req, *args, **kwargs)
 

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -22,10 +22,10 @@ import re
 import string
 import threading
 import time
-from types import MethodType
-from typing import Any, cast, ClassVar, Dict, Optional, Union
 import uuid
 import tqdm
+from types import MethodType
+from typing import Any, cast, ClassVar, Dict, Optional, Union
 
 from google.api_core import retry
 from google.api_core.client_options import ClientOptions

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -573,7 +573,7 @@ class DataprocSparkSession(SparkSession):
         def execute_and_fetch_as_iterator_wrapped_method(
             client_self, req, *args, **kwargs
         ):
-            if not (self._sql_lazy_transformation(req)):
+            if not self._sql_lazy_transformation(req):
                 self._display_operation_link(req.operation_id)
             return execute_and_fetch_as_iterator_base_method(
                 req, *args, **kwargs

--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -587,7 +587,10 @@ class DataprocSparkSession(SparkSession):
     def _sql_lazy_transformation(req):
         # Select SQL command
         if req.plan and req.plan.command and req.plan.command.sql_command:
-            return "select" in req.plan.command.sql_command.sql.lower()
+            return (
+                "select"
+                in req.plan.command.sql_command.sql.strip().lower().split()
+            )
 
         return False
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1662,6 +1662,20 @@ class DataprocSparkConnectClientTest(unittest.TestCase):
             user_context=UserContext(user_id="mock-user-from-super"),
             operation_id=test_uuid,
         )
+        test_execute_plan_request_3: ExecutePlanRequest = ExecutePlanRequest(
+            session_id="mock-session_id-from-super",
+            client_type="mock-client_type-from-super",
+            plan=Plan(
+                command=Command(
+                    sql_command=SqlCommand(
+                        sql="DROP TABLE IF EXISTS selections"
+                    )
+                )
+            ),
+            tags=["mock-tag-from-super"],
+            user_context=UserContext(user_id="mock-user-from-super"),
+            operation_id=test_uuid,
+        )
 
         self.assertTrue(
             DataprocSparkSession._sql_lazy_transformation(
@@ -1671,6 +1685,11 @@ class DataprocSparkConnectClientTest(unittest.TestCase):
         self.assertFalse(
             DataprocSparkSession._sql_lazy_transformation(
                 test_execute_plan_request_2
+            )
+        )
+        self.assertFalse(
+            DataprocSparkSession._sql_lazy_transformation(
+                test_execute_plan_request_3
             )
         )
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -33,7 +33,7 @@ from google.cloud.dataproc_v1 import (
     TerminateSessionRequest,
 )
 from pyspark.sql.connect.client.core import ConfigResult
-from pyspark.sql.connect.proto import ConfigResponse, ExecutePlanRequest, UserContext
+from pyspark.sql.connect.proto import ConfigResponse, ExecutePlanRequest, UserContext, Plan, Command, SqlCommand
 from unittest import mock
 
 
@@ -1469,12 +1469,8 @@ class DataprocSparkConnectClientTest(unittest.TestCase):
     @mock.patch(
         "pyspark.sql.connect.client.SparkConnectClient._execute_plan_request_with_metadata"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.DataprocSparkSession._display_operation_link"
-    )
     def test_execute_plan_request_default_behaviour(
         self,
-        mock_display_operation_link,  # to prevent side effects
         mock_super_execute_plan_request,
         mock_uuid4,
         mock_is_s8s_session_active,
@@ -1530,7 +1526,6 @@ class DataprocSparkConnectClientTest(unittest.TestCase):
 
             mock_super_execute_plan_request.assert_called_once()
             mock_uuid4.assert_called_once()
-            mock_display_operation_link.assert_called_once_with(test_uuid)
 
             self.assertEqual(
                 result_request.session_id, test_execute_plan_request.session_id
@@ -1566,12 +1561,8 @@ class DataprocSparkConnectClientTest(unittest.TestCase):
     @mock.patch(
         "pyspark.sql.connect.client.SparkConnectClient._execute_plan_request_with_metadata"
     )
-    @mock.patch(
-        "google.cloud.dataproc_spark_connect.DataprocSparkSession._display_operation_link"
-    )
     def test_execute_plan_request_with_operation_id_provided(
         self,
-        mock_display_operation_link,  # to prevent side effects
         mock_super_execute_plan_request,
         mock_uuid4,
         mock_is_s8s_session_active,
@@ -1626,7 +1617,6 @@ class DataprocSparkConnectClientTest(unittest.TestCase):
 
             mock_super_execute_plan_request.assert_called_once()
             mock_uuid4.assert_not_called()
-            mock_display_operation_link.assert_called_once_with(provided_uuid)
 
             self.assertEqual(result_request.operation_id, provided_uuid)
             self.assertEqual(
@@ -1649,6 +1639,40 @@ class DataprocSparkConnectClientTest(unittest.TestCase):
                 mock.Mock()
             )
             self.stopSession(mock_session_controller_client_instance, session)
+
+    def test_sql_lazy_transformation(self):
+        test_uuid = "f728f1b4-00a7-4e6e-8365-d12b4a7d42ab"
+        test_execute_plan_request_1: ExecutePlanRequest = ExecutePlanRequest(
+            session_id="mock-session_id-from-super",
+            client_type="mock-client_type-from-super",
+            plan=Plan(command=Command(sql_command=SqlCommand(sql="SELECT 1"))),
+            tags=["mock-tag-from-super"],
+            user_context=UserContext(user_id="mock-user-from-super"),
+            operation_id=test_uuid,
+        )
+        test_execute_plan_request_2: ExecutePlanRequest = ExecutePlanRequest(
+            session_id="mock-session_id-from-super",
+            client_type="mock-client_type-from-super",
+            plan=Plan(
+                command=Command(
+                    sql_command=SqlCommand(sql="INSERT INTO test_table_2 ...")
+                )
+            ),
+            tags=["mock-tag-from-super"],
+            user_context=UserContext(user_id="mock-user-from-super"),
+            operation_id=test_uuid,
+        )
+
+        self.assertTrue(
+            DataprocSparkSession._sql_lazy_transformation(
+                test_execute_plan_request_1
+            )
+        )
+        self.assertFalse(
+            DataprocSparkSession._sql_lazy_transformation(
+                test_execute_plan_request_2
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -33,7 +33,7 @@ from google.cloud.dataproc_v1 import (
     TerminateSessionRequest,
 )
 from pyspark.sql.connect.client.core import ConfigResult
-from pyspark.sql.connect.proto import ConfigResponse, ExecutePlanRequest, UserContext, Plan, Command, SqlCommand
+from pyspark.sql.connect.proto import Command, ConfigResponse, ExecutePlanRequest, Plan, SqlCommand, UserContext
 from unittest import mock
 
 


### PR DESCRIPTION
This is needed to not print the redundant URL when no query gets executed on remote spark server. `SELECT` clause is a transformation evaluated lazily on an action.

**OLD**
<img width="615" height="355" alt="image" src="https://github.com/user-attachments/assets/a1c46a01-93aa-4aec-b9e4-8ba98e53e4b9" />
<img width="651" height="605" alt="image" src="https://github.com/user-attachments/assets/8e7dc237-9ac4-4e87-a68b-0024353cb925" />

**NEW**
<img width="704" height="323" alt="image" src="https://github.com/user-attachments/assets/4340fdb8-efe8-4e6e-b332-c2ea45e3ea50" />
<img width="773" height="585" alt="image" src="https://github.com/user-attachments/assets/a1664b3c-bb99-4119-ba41-2a1a4902b1b5" />
