### PR TITLE
Feature: Add python UDF tests.

### DIFF
--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -15,6 +15,7 @@ import datetime
 import os
 import pytest
 import uuid
+import certifi
 
 from google.api_core import client_options
 from google.cloud.dataproc_spark_connect import DataprocSparkSession
@@ -31,6 +32,8 @@ from google.cloud.dataproc_v1 import (
     TerminateSessionRequest,
 )
 from pyspark.errors.exceptions import connect as connect_exceptions
+from pyspark.sql import functions as F
+from pyspark.sql.types import IntegerType, StringType
 
 
 _SERVICE_ACCOUNT_KEY_FILE_ = "service_account_key.json"
@@ -62,8 +65,9 @@ def test_subnet():
 
 
 @pytest.fixture
-def test_subnetwork_uri(test_project, test_region, test_subnet):
-    return f"projects/{test_project}/regions/{test_region}/subnetworks/{test_subnet}"
+def test_subnetwork_uri(test_subnet):
+    # Make DATAPROC_SPARK_CONNECT_SUBNET the full URI to align with how user would specify it in the project
+    return test_subnet
 
 
 @pytest.fixture
@@ -74,6 +78,9 @@ def os_environment(auth_type, image_version, test_project, test_region):
             _SERVICE_ACCOUNT_KEY_FILE_
         )
     os.environ["DATAPROC_SPARK_CONNECT_AUTH_TYPE"] = auth_type
+    # Add SSL certificate fix
+    os.environ["SSL_CERT_FILE"] = certifi.where()
+    os.environ["REQUESTS_CA_BUNDLE"] = certifi.where()
     yield os.environ
     os.environ.clear()
     os.environ.update(original_environment)
@@ -116,6 +123,7 @@ def session_name(test_project, test_region, connect_session):
 def test_create_spark_session_with_default_notebook_behavior(
     auth_type, connect_session, session_name, session_controller_client
 ):
+    """Test creating a Spark session with default notebook behavior using end user credentials."""
     get_session_request = GetSessionRequest()
     get_session_request.name = session_name
     session = session_controller_client.get_session(get_session_request)
@@ -149,6 +157,7 @@ def test_create_spark_session_with_default_notebook_behavior(
 def test_reuse_s8s_spark_session(
     connect_session, session_name, session_controller_client
 ):
+    """Test that Spark sessions can be reused within the same process."""
     assert DataprocSparkSession._active_s8s_session_uuid is not None
 
     first_session_id = DataprocSparkSession._active_s8s_session_id
@@ -169,6 +178,7 @@ def test_reuse_s8s_spark_session(
 def test_stop_spark_session_with_deleted_serverless_session(
     connect_session, session_name, session_controller_client
 ):
+    """Test stopping a Spark session when the serverless session has been deleted."""
     assert DataprocSparkSession._active_s8s_session_uuid is not None
 
     delete_session_request = DeleteSessionRequest()
@@ -184,6 +194,7 @@ def test_stop_spark_session_with_deleted_serverless_session(
 def test_stop_spark_session_with_terminated_serverless_session(
     connect_session, session_name, session_controller_client
 ):
+    """Test stopping a Spark session when the serverless session has been terminated."""
     assert DataprocSparkSession._active_s8s_session_uuid is not None
 
     terminate_session_request = TerminateSessionRequest()
@@ -205,6 +216,7 @@ def test_get_or_create_spark_session_with_terminated_serverless_session(
     session_name,
     session_controller_client,
 ):
+    """Test creating a new Spark session when the previous serverless session has been terminated."""
     first_session_name = session_name
 
     assert DataprocSparkSession._active_s8s_session_uuid is not None
@@ -291,6 +303,7 @@ def test_create_spark_session_with_session_template_and_user_provided_dataproc_c
     session_template_name,
     session_controller_client,
 ):
+    """Test creating a Spark session with a session template and user-provided Dataproc configuration."""
     dataproc_config = Session()
     dataproc_config.environment_config.execution_config.ttl = {"seconds": 64800}
     dataproc_config.session_template = session_template_name
@@ -330,6 +343,7 @@ def test_create_spark_session_with_session_template_and_user_provided_dataproc_c
 
 
 def test_add_artifacts_pypi_package():
+    """Test adding PyPI packages as artifacts to a Spark session."""
     connect_session = DataprocSparkSession.builder.getOrCreate()
     from pyspark.sql.connect.functions import udf, sum
     from pyspark.sql.types import IntegerType
@@ -353,3 +367,96 @@ def test_add_artifacts_pypi_package():
 
     assert isinstance(sum_random, int), "Result is not of type int"
     connect_session.stop()
+
+
+def test_sql_functions(connect_session):
+    """Test basic SQL functions like col(), sum(), count(), etc."""
+    # Create a test DataFrame
+    df = connect_session.createDataFrame(
+        [(1, "Alice", 100), (2, "Bob", 200), (3, "Charlie", 150)],
+        ["id", "name", "amount"],
+    )
+
+    # Test col() function
+    result_col = df.select(F.col("name")).collect()
+    assert len(result_col) == 3
+    assert result_col[0]["name"] == "Alice"
+
+    # Test aggregation functions
+    sum_result = df.select(F.sum("amount")).collect()[0][0]
+    assert sum_result == 450
+
+    count_result = df.select(F.count("id")).collect()[0][0]
+    assert count_result == 3
+
+    # Test with where clause using col()
+    filtered_df = df.where(F.col("amount") > 150)
+    filtered_count = filtered_df.count()
+    assert filtered_count == 1
+
+    # Test multiple column operations
+    df_with_calc = df.select(
+        F.col("id"),
+        F.col("name"),
+        F.col("amount"),
+        (F.col("amount") * 0.1).alias("tax"),
+    )
+    tax_results = df_with_calc.collect()
+    assert tax_results[0]["tax"] == 10.0
+    assert tax_results[1]["tax"] == 20.0
+
+
+def test_sql_udf(connect_session):
+    """Test SQL UDF registration and usage."""
+    # Create a test DataFrame
+    df = connect_session.createDataFrame(
+        [(1, "hello"), (2, "world"), (3, "spark")], ["id", "text"]
+    )
+
+    # Register DataFrame for SQL queries
+    df.createOrReplaceTempView("test_table")
+
+    # Define and register a Python UDF
+    def uppercase_func(text):
+        return text.upper() if text else None
+
+    # Register UDF using SQL
+    connect_session.udf.register("uppercase_udf", uppercase_func, StringType())
+
+    # Test UDF in SQL query
+    result_sql = connect_session.sql(
+        "SELECT id, text, uppercase_udf(text) as upper_text FROM test_table"
+    ).collect()
+
+    assert len(result_sql) == 3
+    assert result_sql[0]["upper_text"] == "HELLO"
+    assert result_sql[1]["upper_text"] == "WORLD"
+    assert result_sql[2]["upper_text"] == "SPARK"
+
+    # Define another UDF for numeric operations
+    def multiply_by_ten(num):
+        return num * 10 if num is not None else None
+
+    connect_session.udf.register("multiply_udf", multiply_by_ten, IntegerType())
+
+    # Test numeric UDF
+    result_numeric = connect_session.sql(
+        "SELECT id, multiply_udf(id) as multiplied FROM test_table"
+    ).collect()
+
+    assert result_numeric[0]["multiplied"] == 10
+    assert result_numeric[1]["multiplied"] == 20
+    assert result_numeric[2]["multiplied"] == 30
+
+    # Test UDF with DataFrame API
+    uppercase_udf = F.udf(uppercase_func, StringType())
+    df_with_udf = df.select(
+        "id", "text", uppercase_udf(F.col("text")).alias("upper_text")
+    )
+    df_result = df_with_udf.collect()
+
+    assert df_result[0]["upper_text"] == "HELLO"
+    assert df_result[1]["upper_text"] == "WORLD"
+
+    # Clean up
+    connect_session.sql("DROP VIEW IF EXISTS test_table")


### PR DESCRIPTION
Update integration tests for session management and SSL

Notice: Run UDF tests with python 3.11

This commit addresses several issues in the integration tests for Dataproc Spark Connect sessions:

- **Update `test_subnetwork_uri` fixture:** The `test_subnetwork_uri` fixture now returns the `DATAPROC_SPARK_CONNECT_SUBNET` directly, aligning with how users specify the full URI in their projects.
- **Add SSL certificate fix:** Environment variables `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` are now set using `certifi.where()` to resolve potential SSL certificate issues during tests.
- **Add docstrings to session tests:** Descriptive docstrings have been added to various session-related tests to improve clarity and understanding of their purpose.
- **Add `test_sql_functions`:** A new test `test_sql_functions` has been added to verify basic SQL functions like `col()`, `sum()`, and `count()` within a Spark session.
- **Add `test_udf_with_pyspark_connect_functions`:** A new test `test_udf_with_pyspark_connect_functions` has been added to test User Defined Functions (UDFs) with PySpark Connect functions.
- **Add `test_udf_with_pyspark_sql_functions`:** A new test `test_udf_with_pyspark_sql_functions` has been added to test UDFs with PySpark SQL functions.