### PR TITLE
fix: Fix per-operation Spark UI link display logic

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -789,6 +789,11 @@ class DataprocSparkSession(SparkSession):
         """
 
     def _display_operation_link(self, operation_id: str):
+        # Don't print per-operation Spark UI link for non-interactive (despite
+        # Ipython or non-IPython)
+        if not environment.is_interactive():
+            return
+
         assert all(
             [
                 operation_id is not None,
@@ -804,12 +809,13 @@ class DataprocSparkSession(SparkSession):
             f"associatedSqlOperationId={operation_id}?project={self._project_id}"
         )
 
+        if environment.is_interactive_terminal():
+            print(f"Spark Query: {url}")
+            return
+
         try:
             from IPython.display import display, HTML
-            from IPython.core.interactiveshell import InteractiveShell
 
-            if not InteractiveShell.initialized():
-                return
             html_element = f"""
               <div>
                   <p><a href="{url}">Spark Query</a> (Operation: {operation_id})</p>


### PR DESCRIPTION
Notebook:
<img width="1507" height="169" alt="image" src="https://github.com/user-attachments/assets/a7820c14-00a9-4956-8902-5d04ba3a3327" />

Python shell:
<img width="1476" height="155" alt="image" src="https://github.com/user-attachments/assets/3eb02e6d-baeb-40e5-831f-51692f5a00c1" />

IPython shell:
<img width="1462" height="149" alt="image" src="https://github.com/user-attachments/assets/09f5bbaa-0f9c-40bd-a3e1-47b36afbbaa8" />

