### PR TITLE
fix: Ensure DataprocSparkConnectException displays error messages in all Jupyter environments

### DIFF
--- a/google/cloud/dataproc_spark_connect/exceptions.py
+++ b/google/cloud/dataproc_spark_connect/exceptions.py
@@ -27,10 +27,12 @@ def _setup_ipython_exception_handler():
         return
 
     # Store original method if not already stored
-    if hasattr(ipython, "_original_showtraceback"):
+    if hasattr(ipython, "_dataproc_spark_connect_original_showtraceback"):
         return  # Already patched
 
-    ipython._original_showtraceback = ipython.showtraceback
+    ipython._dataproc_spark_connect_original_showtraceback = (
+        ipython.showtraceback
+    )
 
     def custom_showtraceback(
         shell,
@@ -48,7 +50,7 @@ def _setup_ipython_exception_handler():
             print(f"Error: {value.message}", file=sys.stderr)
         else:
             # Use original behavior for other exceptions
-            shell._original_showtraceback(
+            shell._dataproc_spark_connect_original_showtraceback(
                 exc_tuple,
                 filename,
                 tb_offset,


### PR DESCRIPTION
## Summary
Fix silent exception behavior in GCP Workbench where DataprocSparkConnectException error messages weren't displayed without try-catch blocks.

## Problem  
When using default network to create sessions, error messages like 'Subnetwork default does not exist' were:
- Displayed correctly in Google Colab
- Silent in GCP Workbench (Jupyter) without try-catch blocks
- Displayed when wrapped with try-catch

## Root Cause
GCP Workbench's Jupyter implementation doesn't consistently call the _render_traceback_() method.

## Solution
- Added _setup_ipython_exception_handler() that overrides IPython's showtraceback method
- Shows minimal error messages consistently across all Jupyter environments
- Maintains backward compatibility with existing Colab behavior

## Test plan
- Test error display in both Colab and GCP Workbench environments
- Verify non-IPython environments continue working normally