### PR TITLE
test: avoid local env impacting unit test

### DIFF
--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2229,6 +2229,7 @@ class DataprocSparkConnectClientTest(unittest.TestCase):
             )
             self.stopSession(mock_session_controller_client_instance, session)
 
+    @mock.patch.dict(os.environ, {}, clear=True)
     @mock.patch("google.auth.default")
     @mock.patch("google.cloud.dataproc_v1.SessionControllerClient")
     @mock.patch("pyspark.sql.connect.client.SparkConnectClient.config")


### PR DESCRIPTION
 avoid loading the .env file to impact this unit test 

unit tests don't need values from env vars. env vars are for integration test only.
but accidently loading env vars impacted running this unit test