### PR TITLE
fix can't stop session issue

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -519,7 +519,7 @@ class DataprocSparkSession(SparkSession):
             self,
         ) -> Optional["DataprocSparkSession"]:
             s8s_session_id = DataprocSparkSession._active_s8s_session_id
-            session_name = f"projects/{self._project_id}/locations/{self._region}/sessions/{s8s_session_id}"
+            session_name = f"sc://projects/{self._project_id}/locations/{self._region}/sessions/{s8s_session_id}"
             session_response = None
             session = None
             if s8s_session_id is not None:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2313,6 +2313,13 @@ class DataprocSparkConnectClientTest(unittest.TestCase):
                     env_label
                 )
 
+                # If the environment has a subnet configured, add it to the expected request.
+                subnet = os.getenv("DATAPROC_SPARK_CONNECT_SUBNET")
+                if subnet:
+                    expected_request.session.environment_config.execution_config.subnetwork_uri = (
+                        subnet
+                    )
+
                 try:
                     # Reset singleton state before each subtest run
                     DataprocSparkSession._active_s8s_session_id = None


### PR DESCRIPTION
The spark session creation can't be stopped when users click the execution button. Add except  for KeyboardInterrupt to fix.

verified: https://screencast.googleplex.com/cast/NDYyMzU2MDc3MjQxOTU4NHxkYjc1ZWRiMi0yMQ