### PR TITLE
fix: Revert the exception message fix in SC 1.0

### DIFF
--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -348,9 +348,6 @@ def test_create_spark_session_with_session_template_and_user_provided_dataproc_c
     assert DataprocSparkSession._active_s8s_session_uuid is None
 
 
-@pytest.mark.skip(
-    reason="Skipping PyPI package installation test since it's not supported yet"
-)
 def test_add_artifacts_pypi_package():
     """Test adding PyPI packages as artifacts to a Spark session."""
     connect_session = DataprocSparkSession.builder.getOrCreate()


### PR DESCRIPTION
revert [#136 ](https://github.com/GoogleCloudDataproc/dataproc-spark-connect-python/pull/136) in main branch. tested SC 1.0 in jupyter workbench can display error without the change. 