### PR TITLE
fix: Clean up leaked progress bars on session stop

### DIFF
--- a/google/cloud/dataproc_spark_connect/session.py
+++ b/google/cloud/dataproc_spark_connect/session.py
@@ -1259,6 +1259,14 @@ class DataprocSparkSession(SparkSession):
         >>> spark.stop(terminate=False)
         """
         with DataprocSparkSession._lock:
+            # Clean up any remaining progress bars from interrupted operations
+            for pbar in DataprocSparkSession._execution_progress_bar.values():
+                try:
+                    pbar.close()
+                except Exception:
+                    pass
+            DataprocSparkSession._execution_progress_bar.clear()
+
             if DataprocSparkSession._active_s8s_session_id is not None:
                 # Determine if we should terminate the server-side session
                 if terminate is None:


### PR DESCRIPTION
_execution_progress_bar entries are only removed when operations complete with done=True. If operations are interrupted or fail before the handler is called with done=True, their tqdm objects leak. Now clears all remaining progress bars during stop().